### PR TITLE
fix should_run_transactions when db is not 't'

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -547,27 +547,27 @@ mod test {
         let mut lp = Core::new().unwrap();
 
         let fut = Conn::new(&**DATABASE_URL, &lp.handle()).and_then(|conn| {
-            conn.query("CREATE TEMPORARY TABLE t.tmp (id INT, name TEXT)")
+            conn.query("CREATE TEMPORARY TABLE tmp (id INT, name TEXT)")
                 .and_then(|result| result.drop_result())
         }).and_then(|conn| {
             conn.start_transaction(false, None, None)
         }).and_then(|transaction| {
-            transaction.query("INSERT INTO t.tmp VALUES (1, 'foo'), (2, 'bar')")
+            transaction.query("INSERT INTO tmp VALUES (1, 'foo'), (2, 'bar')")
                 .and_then(|result| result.drop_result())
         }).and_then(|transaction| {
             transaction.commit()
         }).and_then(|conn| {
-            conn.first::<(usize, ), _>("SELECT COUNT(*) FROM t.tmp").map(|(result, conn)| {
+            conn.first::<(usize, ), _>("SELECT COUNT(*) FROM tmp").map(|(result, conn)| {
                 assert_eq!(result, Some((2, )));
                 conn
             })
         }).and_then(|conn| {
             conn.start_transaction(false, None, None)
         }).and_then(|transaction| {
-            transaction.query("INSERT INTO t.tmp VALUES (3, 'baz'), (4, 'quux')")
+            transaction.query("INSERT INTO tmp VALUES (3, 'baz'), (4, 'quux')")
                 .and_then(|result| result.drop_result())
         }).and_then(|transaction| {
-            transaction.prep_exec("SELECT COUNT(*) FROM t.tmp", ()).and_then(|result| {
+            transaction.prep_exec("SELECT COUNT(*) FROM tmp", ()).and_then(|result| {
                 result.collect::<(usize,)>()
             }).map(|(set, transaction)| {
                 assert_eq!(set.0[0], (4,));
@@ -576,7 +576,7 @@ mod test {
         }).and_then(|transaction| {
             transaction.rollback()
         }).and_then(|conn| {
-            conn.first::<(usize, ), _>("SELECT COUNT(*) FROM t.tmp").map(|(result, conn)| {
+            conn.first::<(usize, ), _>("SELECT COUNT(*) FROM tmp").map(|(result, conn)| {
                 assert_eq!(result, Some((2, )));
                 conn
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,9 +223,17 @@ pub mod prelude {
 #[cfg(test)]
 mod test_misc {
     use std::env;
+    use opts;
     lazy_static! {
         pub static ref DATABASE_URL: String = {
-            env::var("DATABASE_URL").unwrap_or("mysql://root:password@127.0.0.1:3307/".into())
+            if let Ok(url) = env::var("DATABASE_URL") {
+                if opts::Opts::from_url(&url).expect("DATABASE_URL invalid").get_db_name().expect("a database name is required").is_empty() {
+                    panic!("database name is empty");
+                }
+                url
+            } else {
+                "mysql://root:password@127.0.0.1:3307/mysql".into()
+            }
         };
     }
 }


### PR DESCRIPTION
The test failed when my DATABASE_URL's database was 'test'.