### PR TITLE
Fix parse_named_params() when there's special chrs in the query

### DIFF
--- a/src/conn/named_params.rs
+++ b/src/conn/named_params.rs
@@ -26,7 +26,7 @@ pub fn parse_named_params<'a>(query: &'a str) -> Result<(Option<Vec<String>>, Co
     let mut cur_param = 0;
     // Vec<(start_offset, end_offset, name)>
     let mut params = Vec::new();
-    for (i, c) in query.chars().enumerate() {
+    for (i, c) in query.char_indices() {
         let mut rematch = false;
         match state {
             TopLevel => {
@@ -134,6 +134,12 @@ mod test {
 
         let result = parse_named_params(":1a :2a").unwrap();
         assert_eq!((None, ":1a :2a".into()), result);
+    }
+
+    #[test]
+    fn special_characters_in_query() {
+        let result = parse_named_params(r"SELECT 1 FROM été WHERE thing = :param;").unwrap();
+        assert_eq!((Some(vec!["param".to_string()]), "SELECT 1 FROM été WHERE thing = ?;".into()), result);
     }
 
     #[cfg(feature = "nightly")]


### PR DESCRIPTION
I wasn't able to use mysql-async with queries that have params since I have accentuated characters in some tables.

Params still can't have accentuated characters but it's less critical since I can name the params how I want but I can't rename (easily) the tables.

I may do a second PR for the params.