### PR TITLE
Use wrapping_add with seq_id to avoid overflow in debug-build binaries

### DIFF
--- a/src/conn/futures/new_conn.rs
+++ b/src/conn/futures/new_conn.rs
@@ -97,7 +97,7 @@ impl Future for NewConn {
                                                                         self.opts.get_pass(),
                                                                         self.opts.get_db_name());
                         let future =
-                            stream.write_packet(handshake_response.as_ref().to_vec(), seq_id + 1);
+                            stream.write_packet(handshake_response.as_ref().to_vec(), seq_id.wrapping_add(1));
                         self.step = Step::WriteHandshake(future);
                         self.poll()
                     },

--- a/src/conn/futures/read_packet.rs
+++ b/src/conn/futures/read_packet.rs
@@ -73,7 +73,7 @@ impl Future for ReadPacket {
                         };
                         let mut conn = self.conn.take().unwrap();
                         conn.last_io = SteadyTime::now();
-                        conn.seq_id = seq_id + 1;
+                        conn.seq_id = seq_id.wrapping_add(1);
                         Ok(Ready((conn, packet)))
                     },
                     None => Err(ErrorKind::ConnectionClosed.into()),


### PR DESCRIPTION
Looks like it's already done in `src/io/futures/write_packet.rs`.  Fixes #6 and allows us devs to troubleshoot other problems with our code :stuck_out_tongue_winking_eye: 