### PR TITLE
Use loop instead of recursion to avoid stack overflow

### DIFF
--- a/src/conn/futures/query_result/futures/for_each.rs
+++ b/src/conn/futures/query_result/futures/for_each.rs
@@ -43,12 +43,11 @@ impl<F, T> Future for ForEach<F, T>
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match try_ready!(self.query_result.poll()) {
-            Left(row) => {
-                (&mut self.fun)(row);
-                self.poll()
-            },
-            Right(output) => Ok(Ready(output)),
+        loop {
+            match try_ready!(self.query_result.poll()) {
+                Left(row) => (&mut self.fun)(row),
+                Right(output) => return Ok(Ready(output)),
+            }
         }
     }
 }


### PR DESCRIPTION
I ran across this stack overflow with a simple select query that pulled
more than 342 rows with two fields.

Fixes #8