### PR TITLE
NewPacket.header.len() is required for parsing, do not clear the vector

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -304,7 +304,6 @@ impl NewPacket {
             } else {
                 let length = u24_le(&*self.header).unwrap();
                 self.last_seq_id = self.header[3];
-                self.header.clear();
                 if length == 0 {
                     return ParseResult::Done(Packet { payload: self.data }, self.last_seq_id);
                 } else {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/42610 for details.

I thought this bug was likely an optimization error, but turns out the glitch doesn't occur unless the program is running at full throttle with release target optimizations.

If a TCP packet ends with 4-byte MySQL packet header, and the next TCP packet is slow to arrive, then the MySQL parser will:

1.  Read the 4-byte header, decompose the bytes into length and sequence id, and clear the header vector.
2.  Follow-up with an attempt to copy bytes into data vector, but there are no bytes since that packet hasn't arrived, yet.
3.  Attempt one more parse which...
    1.  find zero bytes in the data vector (still waiting for another TCP packet), and
    2.  finds zero bytes in the header vector (header vector is empty), ...
4.  ...and then proceeds to read subsequent bytes as header info rather than data info.