### PR TITLE
Re-exported some additional items which are needed to provide a custo…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,9 @@ pub use self::queryable::query_result::QueryResult;
 #[doc(inline)]
 pub use self::queryable::transaction::{Transaction, TransactionOptions};
 
+pub use self::queryable::{TextProtocol, BinaryProtocol};
+pub use self::queryable::stmt::Stmt;
+
 /// Futures used in this crate
 mod futures {
     pub use queryable::query_result::{


### PR DESCRIPTION
…m Queryable implementation - Stmt, TextProtocol, BinaryProtocol.

I was struggling to provide a wrapper for a Conn in my own project, to allow mocking for tests.

I wanted to create a trait called ConnWrapper, which had some functions from Conn, then implement that for Conn. Then create an addition 'empty' implementation, which would instead just record what SQL was passed to it in order to be able to test that correct SQL code had been generated.

I couldn't do this with some of the functions I wanted to wrap, because Stmt, TextProtocol and BinaryProtocol weren't visible outside the main crate. I added some lines in the main lib.rs to re-export them.