### PR TITLE
Fix crate name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tokio based asynchronous MySql client library for rust programming language.
 Library hosted on [crates.io](https://crates.io/crates/mysql_async/).
 ```toml
 [dependencies]
-mysql = "<desired version>"
+mysql_async = "<desired version>"
 ```
 
 ### Example


### PR DESCRIPTION
Fixes the crate name mentioned in the readme - should be "mysql_async" and not "mysql".