### PR TITLE
stream: clean-up packet parsing

### DIFF
--- a/src/io/futures/connecting_stream.rs
+++ b/src/io/futures/connecting_stream.rs
@@ -68,14 +68,13 @@ impl Future for ConnectingStream {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match try_ready!(self.either_poll()) {
-            Out::WaitForStream((stream, _)) => {
-                Ok(Ready(Stream {
-                    closed: false,
-                    next_packet: Some(PacketParser::empty().parse()),
-                    buf: Some(Vec::new()),
-                    endpoint: Some(stream.into()),
-                }))
-            }
+            Out::WaitForStream((stream, _)) => Ok(Ready(Stream {
+                closed: false,
+                parser: Some(PacketParser::empty()),
+                packets: Default::default(),
+                buf: Vec::new(),
+                endpoint: Some(stream.into()),
+            })),
             Out::Fail(_) => unreachable!(),
         }
     }


### PR DESCRIPTION
This PR introduces `parse_packet` to cleanup packet parsing in `Stream`. The PR actually fixes several problems/bugs.
 - EOF handling: `AyncRead` returns `Ready(0)` on EOF, but `Stream` didn't handle it correctly [1]. The PR handles the problem.
 - Ensure that exact amount of data is fed into `PacketParser`. It seems that `PacketParser` required to receive exact amount of data returned by `PacketParser::parse`.

The PR solves  problems I observed while using the library.

[1] https://github.com/blackbeam/mysql_async/blob/master/src/io/mod.rs#L298