### PR TITLE
Add support of a custom executor

### DIFF
--- a/src/conn/pool/futures/disconnect_pool.rs
+++ b/src/conn/pool/futures/disconnect_pool.rs
@@ -19,17 +19,17 @@ use std::sync::{atomic, Arc};
 ///
 /// Active connections taken from this pool should be disconnected manually.
 /// Also all pending and new `GetConn`'s will resolve to error.
-pub struct DisconnectPool {
-    pool_inner: Arc<Inner>,
+pub struct DisconnectPool<T: crate::MyExecutor> {
+    pool_inner: Arc<Inner<T>>,
 }
 
-pub fn new(pool: Pool) -> DisconnectPool {
+pub fn new<T: crate::MyExecutor>(pool: Pool<T>) -> DisconnectPool<T> {
     DisconnectPool {
         pool_inner: pool.inner,
     }
 }
 
-impl Future for DisconnectPool {
+impl<T: crate::MyExecutor> Future for DisconnectPool<T> {
     type Item = ();
     type Error = Error;
 

--- a/src/conn/pool/futures/get_conn.rs
+++ b/src/conn/pool/futures/get_conn.rs
@@ -14,29 +14,29 @@ use crate::{
     MyFuture,
 };
 
-pub(crate) enum GetConnInner {
+pub(crate) enum GetConnInner<T: crate::MyExecutor> {
     New,
-    Done(Option<Conn>),
+    Done(Option<Conn<T>>),
     // TODO: one day this should be an existential
     // TODO: impl Drop?
-    Connecting(Box<dyn MyFuture<Conn>>),
+    Connecting(Box<dyn MyFuture<Conn<T>>>),
 }
 
 /// This future will take connection from a pool and resolve to `Conn`.
-pub struct GetConn {
-    pub(crate) pool: Option<Pool>,
-    pub(crate) inner: GetConnInner,
+pub struct GetConn<T: crate::MyExecutor> {
+    pub(crate) pool: Option<Pool<T>>,
+    pub(crate) inner: GetConnInner<T>,
 }
 
-pub fn new(pool: &Pool) -> GetConn {
+pub fn new<T: crate::MyExecutor>(pool: &Pool<T>) -> GetConn<T> {
     GetConn {
         pool: Some(pool.clone()),
         inner: GetConnInner::New,
     }
 }
 
-impl Future for GetConn {
-    type Item = Conn;
+impl<T: crate::MyExecutor> Future for GetConn<T> {
+    type Item = Conn<T>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,23 @@ impl<T, U> MyFuture<T> for U where
 {
 }
 
+/// Alias for supported executor.
+pub trait MyExecutor:
+    ::futures::future::Executor<Box<dyn ::futures::Future<Item = (), Error = ()> + Send + 'static>>
+    + Send
+    + Clone
+    + 'static
+{
+}
+impl<T> MyExecutor for T
+where
+    T: ::futures::future::Executor<
+        Box<dyn ::futures::Future<Item = (), Error = ()> + Send + 'static>,
+    >,
+    T: Send + Clone + 'static,
+{
+}
+
 #[doc(inline)]
 pub use self::conn::Conn;
 

--- a/src/queryable/mod.rs
+++ b/src/queryable/mod.rs
@@ -208,5 +208,5 @@ where
     }
 }
 
-impl Queryable for Conn {}
+impl<E: crate::MyExecutor> Queryable for Conn<E> {}
 impl<T: Queryable + ConnectionLike> Queryable for Transaction<T> {}


### PR DESCRIPTION
This PR adds support of a custom executors (defaults to `tokio::executor::DefaultExecutor`).

Required bounds for supported executors are defined as `MyExecutor` trait.

New constructors:
* `Conn::with_executor`
* `Conn::from_url_with_executor`
* `Pool::with_executor`
* `Pool::from_url_with_executor`

Changes to existing code should be minimal because of default value for new type parameter on `Pool` and `Conn`.