### PR TITLE
Clean up broken and dropped connections

### DIFF
--- a/src/conn/pool/futures/get_conn.rs
+++ b/src/conn/pool/futures/get_conn.rs
@@ -18,8 +18,14 @@ pub(crate) enum GetConnInner {
     New,
     Done(Option<Conn>),
     // TODO: one day this should be an existential
-    // TODO: impl Drop?
     Connecting(Box<dyn MyFuture<Conn>>),
+}
+
+impl GetConnInner {
+    /// Take the value of the inner connection, resetting it to `New`.
+    pub fn take(&mut self) -> GetConnInner {
+        std::mem::replace(self, GetConnInner::New)
+    }
 }
 
 /// This future will take connection from a pool and resolve to `Conn`.
@@ -48,6 +54,7 @@ impl Future for GetConn {
                     .expect("GetConn::poll polled after returning Async::Ready")
                     .poll_new_conn())
                 .inner
+                .take()
                 {
                     GetConnInner::Done(Some(conn)) => {
                         self.inner = GetConnInner::Done(Some(conn));
@@ -75,14 +82,40 @@ impl Future for GetConn {
                     unreachable!("GetConn::poll polled after returning Async::Ready");
                 }
                 GetConnInner::Connecting(ref mut f) => {
-                    let mut c = try_ready!(f.poll());
-                    c.inner.pool = Some(
-                        self.pool
-                            .take()
-                            .expect("GetConn::poll polled after returning Async::Ready"),
-                    );
-                    return Ok(Async::Ready(c));
+                    let result = match f.poll() {
+                        Ok(Async::NotReady) => return Ok(Async::NotReady),
+                        Ok(Async::Ready(c)) => Ok(c),
+                        Err(e) => Err(e),
+                    };
+
+                    let pool = self
+                        .pool
+                        .take()
+                        .expect("GetConn::poll polled after returning Async::Ready");
+
+                    return match result {
+                        Ok(mut c) => {
+                            c.inner.pool = Some(pool);
+                            Ok(Async::Ready(c))
+                        }
+                        Err(e) => {
+                            pool.release_conn();
+                            Err(e)
+                        }
+                    };
                 }
+            }
+        }
+    }
+}
+
+impl Drop for GetConn {
+    fn drop(&mut self) {
+        // We drop a connection before it can be resolved, a.k.a. cancelling it.
+        // Make sure we maintain the necessary invariants towards the pool.
+        if let Some(pool) = self.pool.take() {
+            if let GetConnInner::Connecting(..) = self.inner.take() {
+                pool.release_conn();
             }
         }
     }

--- a/src/conn/pool/futures/get_conn.rs
+++ b/src/conn/pool/futures/get_conn.rs
@@ -99,7 +99,7 @@ impl Future for GetConn {
                             Ok(Async::Ready(c))
                         }
                         Err(e) => {
-                            pool.release_conn();
+                            pool.cancel_connection();
                             Err(e)
                         }
                     };
@@ -115,7 +115,7 @@ impl Drop for GetConn {
         // Make sure we maintain the necessary invariants towards the pool.
         if let Some(pool) = self.pool.take() {
             if let GetConnInner::Connecting(..) = self.inner.take() {
-                pool.release_conn();
+                pool.cancel_connection();
             }
         }
     }

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -337,7 +337,7 @@ impl Pool {
     ///
     /// Decreases the exist counter since a broken or dropped connection should not count towards
     /// the total.
-    fn release_conn(&self) {
+    fn cancel_connection(&self) {
         self.inner.exist.fetch_sub(1, atomic::Ordering::AcqRel);
     }
 

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -338,7 +338,9 @@ impl Pool {
     /// Decreases the exist counter since a broken or dropped connection should not count towards
     /// the total.
     fn cancel_connection(&self) {
-        self.inner.exist.fetch_sub(1, atomic::Ordering::AcqRel);
+        let prev = self.inner.exist.fetch_sub(1, atomic::Ordering::AcqRel);
+        // NB: Wrapping around here would only be due to a programming error.
+        assert!(prev > 0, "exist must not wrap around");
     }
 
     /// Poll the pool for an available connection.
@@ -700,6 +702,48 @@ mod test {
             });
 
         run(fut).unwrap();
+    }
+
+    #[test]
+    fn should_hold_bounds_on_error() {
+        // Test that connections which err do not count towards the connection count in the pool.
+
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+
+        // Should not be possible to connect to broadcast address.
+        let pool = Pool::new(String::from("mysql://255.255.255.255"));
+
+        let result = runtime.block_on(pool.get_conn().join(pool.get_conn()));
+
+        assert!(result.is_err());
+        assert_eq!(pool.inner.exist.load(atomic::Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn should_hold_bounds_on_get_conn_drop() {
+        let pool = Pool::new(format!("{}?pool_min=1&pool_max=2", &**DATABASE_URL));
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+
+        // This test is a bit more intricate: we need to poll the connection future once to get the
+        // pool to set it up, then drop it and make sure that the `exist` count is updated.
+        //
+        // We wrap all of it in a lazy future to get us into the tokio context that deals with
+        // setting up tasks. There might be a better way to do this but I don't remember right
+        // now. Besides, std::future is just around the corner making this obsolete.
+        //
+        // It depends on implementation details of GetConn, but that should be fine.
+        runtime
+            .block_on(future::lazy(move || {
+                let mut conn = pool.get_conn();
+                assert_eq!(pool.inner.exist.load(atomic::Ordering::SeqCst), 0);
+                let result = conn.poll().expect("successful first poll");
+                assert!(result.is_not_ready(), "not ready after first poll");
+                assert_eq!(pool.inner.exist.load(atomic::Ordering::SeqCst), 1);
+                drop(conn);
+                assert_eq!(pool.inner.exist.load(atomic::Ordering::SeqCst), 0);
+                Ok::<(), ()>(())
+            }))
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
This should be a first step towards fixing #68.

We currently don't maintain pool invariants if a connection errors or is dropped (`exist` to be specific). This patch should fix that.

Also renames `should_hold_bounds` to `should_hold_bounds1` to make it easier to run that test by itself.