### PR TITLE
Fix payload parsing in InnerStmt::new

### DIFF
--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -41,12 +41,18 @@ pub struct InnerStmt {
 
 impl InnerStmt {
     // TODO: Consume payload?
-    pub fn new(pld: &[u8], named_params: Option<Vec<String>>) -> Result<InnerStmt> {
-        let mut reader = &pld[1..];
-        let statement_id = reader.read_u32::<LE>()?;
-        let num_columns = reader.read_u16::<LE>()?;
-        let num_params = reader.read_u16::<LE>()?;
-        let warning_count = reader.read_u16::<LE>()?;
+    pub fn new(payload: &[u8], named_params: Option<Vec<String>>) -> Result<InnerStmt> {
+        let mut payload = &payload[..];
+
+        if payload.read_u8()? != 0x00 {
+            panic!("Invalid statement packet status");
+        }
+
+        let statement_id = payload.read_u32::<LE>()?;
+        let num_columns = payload.read_u16::<LE>()?;
+        let num_params = payload.read_u16::<LE>()?;
+        payload.read_u8()?;
+        let warning_count = payload.read_u16::<LE>()?;
         Ok(InnerStmt {
             named_params,
             statement_id,

--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -42,23 +42,15 @@ pub struct InnerStmt {
 impl InnerStmt {
     // TODO: Consume payload?
     pub fn new(payload: &[u8], named_params: Option<Vec<String>>) -> Result<InnerStmt> {
-        let mut payload = &payload[..];
+        let packet: mysql_common::packets::StmtPacket =
+            mysql_common::packets::parse_stmt_packet(payload)?;
 
-        if payload.read_u8()? != 0x00 {
-            panic!("Invalid statement packet status");
-        }
-
-        let statement_id = payload.read_u32::<LE>()?;
-        let num_columns = payload.read_u16::<LE>()?;
-        let num_params = payload.read_u16::<LE>()?;
-        payload.read_u8()?;
-        let warning_count = payload.read_u16::<LE>()?;
         Ok(InnerStmt {
             named_params,
-            statement_id,
-            num_columns,
-            num_params,
-            warning_count,
+            statement_id: packet.statement_id(),
+            num_columns: packet.num_columns(),
+            num_params: packet.num_params(),
+            warning_count: packet.warning_count(),
             params: None,
             columns: None,
         })


### PR DESCRIPTION
I encountered a crash in InnerStmt::new. I haven't been able to produce a minimal example for reproducing the error, but this fixes it in my tests. I ported [the logic from the new mysql-common](https://github.com/blackbeam/rust_mysql_common/blob/f72056d9cd6e55e6b07c5e75cdaad972ccf69644/src/packets.rs#L1141).