### PR TITLE
Update mysql_async to tokio 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,23 @@ exclude = ["test/*"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
+old_bytes = { version = "0.4", package = "bytes" }
 crossbeam = "0.7"
-futures-core-preview = "=0.3.0-alpha.19"
-futures-util-preview = "=0.3.0-alpha.19"
-futures-sink-preview = "=0.3.0-alpha.19"
+futures-core = "0.3"
+futures-util = "0.3"
+futures-sink = "0.3"
 mio-named-pipes = "0.1.6"
 mysql_common = "0.19.2"
 native-tls = "0.2"
 percent-encoding = "2.1.0"
-pin-project = "0.4.0"
+pin-project = "0.4.6"
 serde = "1"
 serde_json = "1"
 thiserror = "1.0.4"
-# we only need rt-full for tokio::spawn
-tokio = { version = "=0.2.0-alpha.6", default-features = false, features = ["codec", "io", "net", "sync", "fs", "rt-full"] }
-tokio-tls = "=0.3.0-alpha.6"
-tokio-net = "=0.2.0-alpha.6"
+tokio = { version = "0.2", features = ["io-util", "net", "sync", "fs", "rt-core", "time", "stream", "macros"] }
+tokio-util = { version = "0.2", features = ["codec"] }
+tokio-tls = "0.3"
 twox-hash = "1"
 url = "2.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,13 @@ exclude = ["test/*"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
-old_bytes = { version = "0.4", package = "bytes" }
+bytes = "0.5.2"
 crossbeam = "0.7"
 futures-core = "0.3"
 futures-util = "0.3"
 futures-sink = "0.3"
 mio-named-pipes = "0.1.6"
-mysql_common = "0.19.2"
+mysql_common = "0.20.0"
 native-tls = "0.2"
 percent-encoding = "2.1.0"
 pin-project = "0.4.6"

--- a/src/conn/pool/ttl_check_inerval.rs
+++ b/src/conn/pool/ttl_check_inerval.rs
@@ -9,7 +9,7 @@
 use futures_util::future::FutureExt;
 use futures_util::stream::{StreamExt, StreamFuture};
 use pin_project::pin_project;
-use tokio::timer::Interval;
+use tokio::time::{self, Interval};
 
 use std::future::Future;
 use std::sync::atomic::Ordering;
@@ -18,8 +18,7 @@ use std::sync::Arc;
 use super::Inner;
 use crate::prelude::Queryable;
 use crate::PoolOptions;
-use futures_core::task::Context;
-use futures_core::Poll;
+use futures_core::task::{Context, Poll};
 use std::pin::Pin;
 
 /// Idling connections TTL check interval.
@@ -38,7 +37,7 @@ pub struct TtlCheckInterval {
 impl TtlCheckInterval {
     /// Creates new `TtlCheckInterval`.
     pub fn new(pool_options: PoolOptions, inner: Arc<Inner>) -> Self {
-        let interval = Interval::new_interval(pool_options.ttl_check_interval()).into_future();
+        let interval = time::interval(pool_options.ttl_check_interval()).into_future();
         Self {
             inner,
             interval,

--- a/src/io/async_tls.rs
+++ b/src/io/async_tls.rs
@@ -18,6 +18,8 @@ use tokio::io::Error as IoError;
 use tokio::prelude::*;
 use tokio_tls::{self};
 
+use std::mem::MaybeUninit;
+
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.
 ///
@@ -52,7 +54,7 @@ where
         self.project().inner.poll_read(cx, buf)
     }
 
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [MaybeUninit<u8>]) -> bool {
         self.inner.prepare_uninitialized_buffer(buf)
     }
 

--- a/src/io/futures/connecting_tcp_stream.rs
+++ b/src/io/futures/connecting_tcp_stream.rs
@@ -7,8 +7,8 @@
 // modified, or distributed except according to those terms.
 
 use futures_util::stream::{FuturesUnordered, StreamExt};
-use tokio::codec::Framed;
 use tokio::net::TcpStream;
+use tokio_util::codec::Framed;
 
 use std::{io, net::ToSocketAddrs};
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -63,12 +63,7 @@ impl Decoder for PacketCodec {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
-        // TODO: Remove once `mysql_common` switched to a newer `bytes` crate!
-        let mut old_src = old_bytes::BytesMut::from(src.as_ref());
-        let res = self.0.decode(&mut old_src)?;
-        let new_src = BytesMut::from(old_src.as_ref());
-        *src = new_src;
-        Ok(res)
+        Ok(self.0.decode(src)?)
     }
 }
 
@@ -77,11 +72,7 @@ impl Encoder for PacketCodec {
     type Error = Error;
 
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<()> {
-        // TODO: Remove once `mysql_common` switched to a newer `bytes` crate!
-        let mut old_dst = old_bytes::BytesMut::with_capacity(dst.capacity());
-        self.0.encode(item, &mut old_dst)?;
-        dst.extend_from_slice(old_dst.as_ref());
-        Ok(())
+        Ok(self.0.encode(item, dst)?)
     }
 }
 


### PR DESCRIPTION
This is a recommendation to update to tokio 0.2, once the ecosystem is ready.

Please note that there's a gross hack to support the current version of `mysql_common` while the crate should actually be updated to use `bytes` 0.5.