### PR TITLE
mysql_async: Fix IPv6 address support when using a URL

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -392,7 +392,7 @@ impl Conn {
         let stream = if let Some(path) = opts.get_socket() {
             Stream::connect_socket(path.to_owned()).await?
         } else {
-            Stream::connect_tcp((opts.get_ip_or_hostname(), opts.get_tcp_port())).await?
+            Stream::connect_tcp(opts.get_hostport_or_url()).await?
         };
 
         conn.inner.stream = Some(stream);


### PR DESCRIPTION
When passing an IPv6 address to mysql_async in a form such as
`mysql://user@[::1]:123`, the IPv6 address will be treated as a domain
that is resolved rather than an IPv6 address.

This was root caused by @rdna, who submitted
https://github.com/blackbeam/mysql_async/pull/91. My PR builds upon his
work and includes some refactoring to prevent similar issues in the future.

The bug is due to mysql_async parsing the url string to a `url::Url` and then
calling `url.host_str()` before storing the resulting value in
`ip_or_hostname`. When a new TCP stream is created `to_socket_addrs()` is
called using a tuple of `(ip_or_hostname, tcp_port)` which attempts to
first parse the `ip_or_hostname` as an IPv4 address, then an IPv6 address
before finally falling back to resolving the `ip_or_hostname` using DNS.

When using an IPv6 address, `url.host_str()` returns a string that
contains [ and ]. Rust's `std::net::Ipv6Addr` doesn't support parsing
such an address and fails - causing `to_socket_addr` to fallback to
resolving the IPv6 address as a hostname.

Fix this by using `url::Url`'s `socket_addr()` method to perform the
conversion, rather than relying on a `(&str, u16)` tuple. As part of this
work, create an enum that allows turning a host:port combo or URL into a
`SocketAddr` without relying on passing strings around.

Further, refactor the code to split the MySQL options from the address
options.

I tested this by running the new unit tests, as well as creating a
connection to a MySQL server listening only on `[::1]`.

Signed-off-by: harveyhunt <harveyhunt@fb.com>