### PR TITLE
Completely shut down connections on disconnect

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -330,6 +330,15 @@ impl Stream {
             codec.codec_mut().compress(level);
         }
     }
+
+    pub async fn close(mut self) -> Result<()> {
+        self.closed = true;
+        if let Some(mut codec) = self.codec {
+            use futures_sink::Sink;
+            futures_util::future::poll_fn(|cx| Pin::new(&mut *codec).poll_close(cx)).await?;
+        }
+        Ok(())
+    }
 }
 
 impl stream::Stream for Stream {

--- a/src/queryable/mod.rs
+++ b/src/queryable/mod.rs
@@ -90,7 +90,8 @@ where
         self.on_disconnect();
         let f = self.write_command_data(Command::COM_QUIT, &[]);
         Box::pin(async move {
-            f.await?;
+            let (_, stream) = f.await?.take_stream();
+            stream.close().await?;
             Ok(())
         })
     }


### PR DESCRIPTION
Previously, connections that got replaced (due to `reset` or an upgrade
to `Socket`) were simply dropped and left to be cleaned up by spawning
the disconnect routine. This patch makes them be torn down when the new
connection is established instead.

This patch also ensures that we completely close the underlying stream
during cleanup, to minimize the time during which we hold up resources
as the server.