### PR TITLE
Reexport 'vendored' feature from native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tempfile = "3.1.0"
 
 [features]
 nightly = []
+native-tls-vendored = ["native-tls/vendored"]
 
 [lib]
 name = "mysql_async"


### PR DESCRIPTION
Allows easier cross-compilation to non-Windows, non-macOS targets by using the "vendored" feature from native-tls to compile OpenSSL from scratch instead of finding and installing OpenSSL lib files and headers.