### PR TITLE
Make QueryResult::new public

### DIFF
--- a/src/queryable/query_result.rs
+++ b/src/queryable/query_result.rs
@@ -54,7 +54,7 @@ impl<'a, 't: 'a, P> QueryResult<'a, 't, P>
 where
     P: Protocol,
 {
-    pub(crate) fn new<T: Into<Connection<'a, 't>>>(conn: T) -> Self {
+    pub fn new<T: Into<Connection<'a, 't>>>(conn: T) -> Self {
         QueryResult {
             conn: conn.into(),
             __phantom: PhantomData,


### PR DESCRIPTION
Allow re-using query result between multiple features by allowing to re-instantiate query results.

Right now it is impossible to consume query results in multiple async functions when connection is moved as a result from future. Making new method public allows to re-create query result in another future and continue processing the result.