### PR TITLE
Next item feature (Fixes #121)

### DIFF
--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -172,7 +172,7 @@ impl Pool {
             && !conn.inner.disconnected
             && !conn.expired()
             && conn.inner.tx_status == TxStatus::None
-            && conn.inner.pending_result.is_none()
+            && conn.get_pending_result().is_none()
             && !self.inner.close.load(atomic::Ordering::Acquire)
         {
             let mut exchange = self.inner.exchange.lock().unwrap();

--- a/src/conn/pool/recycler.rs
+++ b/src/conn/pool/recycler.rs
@@ -68,7 +68,7 @@ impl Future for Recycler {
                         .discard
                         .push(BoxFuture(Box::pin(::futures_util::future::ok(()))));
                 } else if $conn.inner.tx_status != TxStatus::None
-                    || $conn.inner.pending_result.is_some()
+                    || $conn.get_pending_result().is_some()
                 {
                     $self.cleaning.push(BoxFuture(Box::pin($conn.cleanup())));
                 } else if $conn.expired() || close {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub use mysql_common::value::convert::{from_value, from_value_opt, FromValueErro
 pub use mysql_common::value::json::{Deserialized, Serialized};
 
 #[doc(inline)]
-pub use self::queryable::query_result::QueryResult;
+pub use self::queryable::query_result::{NextItem, QueryResult};
 
 #[doc(inline)]
 pub use self::queryable::transaction::{Transaction, TxOpts};

--- a/tests/exports.rs
+++ b/tests/exports.rs
@@ -8,8 +8,8 @@ use mysql_async::{
         StatementLike, ToValue,
     },
     time, uuid, BinaryProtocol, BoxFuture, Column, Conn, Deserialized, DriverError, Error,
-    FromRowError, FromValueError, IoError, IsolationLevel, Opts, OptsBuilder, Params, ParseError,
-    Pool, PoolConstraints, PoolOpts, QueryResult, Result, Row, Serialized, ServerError, SslOpts,
-    Statement, TextProtocol, Transaction, TxOpts, UrlError, Value, WhiteListFsLocalInfileHandler,
-    DEFAULT_INACTIVE_CONNECTION_TTL, DEFAULT_TTL_CHECK_INTERVAL,
+    FromRowError, FromValueError, IoError, IsolationLevel, NextItem, Opts, OptsBuilder, Params,
+    ParseError, Pool, PoolConstraints, PoolOpts, QueryResult, Result, Row, Serialized, ServerError,
+    SslOpts, Statement, TextProtocol, Transaction, TxOpts, UrlError, Value,
+    WhiteListFsLocalInfileHandler, DEFAULT_INACTIVE_CONNECTION_TTL, DEFAULT_TTL_CHECK_INTERVAL,
 };


### PR DESCRIPTION
NextItem type adds distinction between empty result set and just end of
the result set that had rows previously.

- Introduced ResultSetMetaState to distinguish between fetched row and not
  fetched yet result
- Introduced NextItem to return back EmptyResult with columns that are
  impossible to fetch if next is called instead