### PR TITLE
Close statement after use, if LRU is off

### DIFF
--- a/src/conn/stmt_cache.rs
+++ b/src/conn/stmt_cache.rs
@@ -99,6 +99,10 @@ impl StmtCache {
         }
     }
 
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+
     #[cfg(test)]
     pub fn iter(&self) -> impl Iterator<Item = (&u32, &Entry)> {
         self.cache.iter()


### PR DESCRIPTION
If we do not close the statement here, we'll leak them and hit the server maximum limit.