### PR TITLE
Fix documentation by explicitly dropping connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!     ).await?;
 //!
 //!     // Dropped connection will go to the pool
-//!     conn;
+//!     drop(conn);
 //!
 //!     // Pool must be disconnected explicitly because
 //!     // it's an asynchronous operation.

--- a/src/local_infile_handler/mod.rs
+++ b/src/local_infile_handler/mod.rs
@@ -64,7 +64,7 @@ pub mod builtin;
 /// assert_eq!(result.len(), 1);
 /// assert_eq!(result[0], "foobar");
 ///
-/// conn; // dropped connection will go to the pool
+/// drop(conn); // dropped connection will go to the pool
 ///
 /// pool.disconnect().await?;
 /// # Ok(())


### PR DESCRIPTION
Fix documentation by explicitly dropping connection

Everywhere in code we use `drop(conn);`. I guess docs were left out when this change happened.

Without this rustc will complain:
```
  --> tests/health_check.rs:52:5
   |
52 |     conn;
   |     ^^^^^ help: use `drop` to clarify the intent: `drop(conn);`
   |
   = note: `#[warn(path_statements)]` on by default
```