### PR TITLE
Fix panic macro use

### DIFF
--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -645,7 +645,7 @@ mod test {
                 .block_on(async {
                     let pool = Pool::new(get_opts());
                     let _conn = pool.get_conn().await.unwrap();
-                    panic!(PANIC_MESSAGE);
+                    std::panic::panic_any(PANIC_MESSAGE);
                 });
         });
 


### PR DESCRIPTION
Fix panic macro use

Without this rustc complains:

```
warning: panic message is not a string literal
   --> src/conn/pool/mod.rs:648:28
    |
648 |                     panic!(PANIC_MESSAGE);
    |                            ^^^^^^^^^^^^^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
648 |                     panic!("{}", PANIC_MESSAGE);
    |                            ^^^^^
help: or use std::panic::panic_any instead
    |
648 |                     std::panic::panic_any(PANIC_MESSAGE);
    |                     ^^^^^^^^^^^^^^^^^^^^^
```