### PR TITLE
replace experimental or-pattern by splitted match cases

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -390,9 +390,8 @@ impl Conn {
         self.inner.id = handshake.connection_id();
         self.inner.status = handshake.status_flags();
         self.inner.auth_plugin = match handshake.auth_plugin() {
-            Some(AuthPlugin::MysqlNativePassword | AuthPlugin::MysqlOldPassword) => {
-                AuthPlugin::MysqlNativePassword
-            }
+            Some(AuthPlugin::MysqlNativePassword) => AuthPlugin::MysqlNativePassword,
+            Some(AuthPlugin::MysqlOldPassword) => AuthPlugin::MysqlNativePassword,
             Some(AuthPlugin::CachingSha2Password) => AuthPlugin::CachingSha2Password,
             Some(AuthPlugin::Other(ref name)) => {
                 let name = String::from_utf8_lossy(name).into();


### PR DESCRIPTION
currently mysql_async doesn't compile on `stable` due to an experimental or-pattern:

```
   Compiling mysql_async v0.28.0
error[E0658]: or-patterns syntax is experimental
   --> .../mysql_async-0.28.0/src/conn/mod.rs:393:18
    |
393 |             Some(AuthPlugin::MysqlNativePassword | AuthPlugin::MysqlOldPassword) => {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information

```

replace or-pattern by both cases