### PR TITLE
Implement `QueryResult::stream` (fix #166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tokio based asynchronous MySql client library for rust programming language.
 
 ### Installation
 
-Library hosted on [crates.io](https://crates.io/crates/mysql_async/).
+The library is hosted on [crates.io](https://crates.io/crates/mysql_async/).
 ```toml
 [dependencies]
 mysql_async = "<desired version>"
@@ -19,7 +19,7 @@ mysql_async = "<desired version>"
 
 ### Example
 
-See crate documentation on [docs.rs](https://docs.rs/mysql_async).
+Please see the crate docs – [docs.rs](https://docs.rs/mysql_async).
 
 ### License
 

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -184,7 +184,7 @@ impl Pool {
             && !conn.inner.disconnected
             && !conn.expired()
             && conn.inner.tx_status == TxStatus::None
-            && conn.inner.pending_result.is_none()
+            && !conn.has_pending_result()
             && !self.inner.close.load(atomic::Ordering::Acquire)
         {
             let mut exchange = self.inner.exchange.lock().unwrap();

--- a/src/conn/pool/recycler.rs
+++ b/src/conn/pool/recycler.rs
@@ -65,9 +65,7 @@ impl Future for Recycler {
                 if $conn.inner.stream.is_none() || $conn.inner.disconnected {
                     // drop unestablished connection
                     $self.discard.push(futures_util::future::ok(()).boxed());
-                } else if $conn.inner.tx_status != TxStatus::None
-                    || $conn.inner.pending_result.is_some()
-                {
+                } else if $conn.inner.tx_status != TxStatus::None || $conn.has_pending_result() {
                     $self.cleaning.push($conn.cleanup_for_pool().boxed());
                 } else if $conn.expired() || close {
                     $self.discard.push($conn.close_conn().boxed());

--- a/src/connection_like/mod.rs
+++ b/src/connection_like/mod.rs
@@ -79,6 +79,17 @@ impl<'a, 't: 'a, T: Into<Connection<'a, 't>> + Send> ToConnection<'a, 't> for T 
     }
 }
 
+impl ToConnection<'static, 'static> for Pool {
+    fn to_connection(self) -> ToConnectionResult<'static, 'static> {
+        let fut = async move {
+            let conn = self.get_conn().await?;
+            Ok(conn.into())
+        }
+        .boxed();
+        ToConnectionResult::Mediate(fut)
+    }
+}
+
 impl<'a> ToConnection<'a, 'static> for &'a Pool {
     fn to_connection(self) -> ToConnectionResult<'a, 'static> {
         let fut = async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! ```
 
 #![recursion_limit = "1024"]
-#![cfg_attr(feature = "nightly", feature(test, const_fn))]
+#![cfg_attr(feature = "nightly", feature(test))]
 
 #[cfg(feature = "nightly")]
 extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ pub use mysql_common::value::convert::{from_value, from_value_opt, FromValueErro
 pub use mysql_common::value::json::{Deserialized, Serialized};
 
 #[doc(inline)]
-pub use self::queryable::query_result::QueryResult;
+pub use self::queryable::query_result::{result_set_stream::ResultSetStream, QueryResult};
 
 #[doc(inline)]
 pub use self::queryable::transaction::{Transaction, TxOpts};
@@ -236,9 +236,12 @@ pub mod prelude {
     impl<T: crate::queryable::stmt::StatementLike> StatementLike for T {}
 
     /// Everything that is a connection.
+    ///
+    /// Note that you could obtain a `'static` connection by giving away `Conn` or `Pool`.
     pub trait ToConnection<'a, 't: 'a>: crate::connection_like::ToConnection<'a, 't> {}
     // explicitly implemented because of rusdoc
     impl<'a> ToConnection<'a, 'static> for &'a crate::Pool {}
+    impl<'a> ToConnection<'static, 'static> for crate::Pool {}
     impl ToConnection<'static, 'static> for crate::Conn {}
     impl<'a> ToConnection<'a, 'static> for &'a mut crate::Conn {}
     impl<'a, 't> ToConnection<'a, 't> for &'a mut crate::Transaction<'t> {}

--- a/src/queryable/query_result/result_set_stream.rs
+++ b/src/queryable/query_result/result_set_stream.rs
@@ -1,0 +1,348 @@
+// Copyright (c) 2021 mysql_async developers.
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::any::type_name;
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::task::Poll;
+use std::{fmt, marker::PhantomData};
+
+use futures_core::FusedStream;
+use futures_core::{future::BoxFuture, Stream};
+use futures_util::FutureExt;
+use mysql_common::packets::{Column, OkPacket};
+
+use crate::{
+    conn::PendingResult,
+    prelude::{FromRow, Protocol},
+    QueryResult, Row,
+};
+
+enum CowMut<'r, 'a: 'r, 't: 'a, P> {
+    Borrowed(&'r mut QueryResult<'a, 't, P>),
+    Owned(QueryResult<'a, 't, P>),
+}
+
+impl<'r, 'a: 'r, 't: 'a, P> fmt::Debug for CowMut<'r, 'a, 't, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Borrowed(arg0) => f.debug_tuple("Borrowed").field(arg0).finish(),
+            Self::Owned(arg0) => f.debug_tuple("Owned").field(arg0).finish(),
+        }
+    }
+}
+
+impl<'r, 'a: 'r, 't: 'a, P> AsMut<QueryResult<'a, 't, P>> for CowMut<'r, 'a, 't, P> {
+    fn as_mut(&mut self) -> &mut QueryResult<'a, 't, P> {
+        match self {
+            CowMut::Borrowed(q) => q,
+            CowMut::Owned(q) => q,
+        }
+    }
+}
+
+enum ResultSetStreamState<'r, 'a: 'r, 't: 'a, P> {
+    Idle(CowMut<'r, 'a, 't, P>),
+    NextFut(BoxFuture<'r, (crate::Result<Option<Row>>, CowMut<'r, 'a, 't, P>)>),
+}
+
+impl<'r, 'a: 'r, 't: 'a, P> fmt::Debug for ResultSetStreamState<'r, 'a, 't, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Idle(arg0) => f.debug_tuple("Idle").field(arg0).finish(),
+            Self::NextFut(_arg0) => f
+                .debug_tuple("NextFut")
+                .field(&type_name::<
+                    BoxFuture<'r, (crate::Result<Option<Row>>, CowMut<'r, 'a, 't, P>)>,
+                >())
+                .finish(),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Rows stream for a single result set.
+pub struct ResultSetStream<'r, 'a: 'r, 't: 'a, T, P> {
+    query_result: Option<ResultSetStreamState<'r, 'a, 't, P>>,
+    ok_packet: Option<OkPacket<'static>>,
+    columns: Arc<[Column]>,
+    __from_row_type: PhantomData<T>,
+}
+
+impl<'r, 'a: 'r, 't: 'a, T, P> FusedStream for ResultSetStream<'r, 'a, 't, T, P>
+where
+    P: Protocol + Unpin,
+    T: FromRow + Unpin + Send + 'static,
+{
+    fn is_terminated(&self) -> bool {
+        self.query_result.is_none()
+    }
+}
+
+impl<'r, 'a: 'r, 't: 'a, T, P> ResultSetStream<'r, 'a, 't, T, P> {
+    /// See [`Conn::last_insert_id`][1].
+    ///
+    /// [1]: crate::Conn::last_insert_id
+    pub fn last_insert_id(&self) -> Option<u64> {
+        self.ok_packet.as_ref().and_then(|ok| ok.last_insert_id())
+    }
+
+    /// See [`Conn::affected_rows`][1].
+    ///
+    /// [1]: crate::Conn::affected_rows
+    pub fn affected_rows(&self) -> u64 {
+        self.ok_packet
+            .as_ref()
+            .map(|ok| ok.affected_rows())
+            .unwrap_or_default()
+    }
+
+    /// See [`Conn::info`][1].
+    ///
+    /// [1]: crate::Conn::info
+    pub fn info(&self) -> Cow<'_, str> {
+        self.ok_packet
+            .as_ref()
+            .and_then(|ok| ok.info_str())
+            .unwrap_or_default()
+    }
+
+    /// See [`Conn::get_warnings`][1].
+    ///
+    /// [1]: crate::Conn::get_warnings
+    pub fn get_warnings(&self) -> u16 {
+        self.ok_packet
+            .as_ref()
+            .map(|ok| ok.warnings())
+            .unwrap_or_default()
+    }
+
+    /// Returns an `OkPacket` corresponding to this result set.
+    ///
+    /// Will be `None` if there is no OK packet (result set contains an error).
+    pub fn ok_packet(&self) -> Option<&OkPacket<'static>> {
+        self.ok_packet.as_ref()
+    }
+}
+
+impl<'r, 'a: 'r, 't: 'a, T, P> Stream for ResultSetStream<'r, 'a, 't, T, P>
+where
+    P: Protocol + Unpin,
+    T: FromRow + Unpin + Send + 'static,
+{
+    type Item = crate::Result<T>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            let columns = this.columns.clone();
+            match this.query_result.take() {
+                Some(ResultSetStreamState::Idle(mut query_result)) => {
+                    let fut = Box::pin(async move {
+                        let row = query_result.as_mut().next_row_or_next_set2(columns).await;
+                        (row, query_result)
+                    });
+                    this.query_result = Some(ResultSetStreamState::NextFut(fut));
+                }
+                Some(ResultSetStreamState::NextFut(mut fut)) => match fut.poll_unpin(cx) {
+                    Poll::Ready((row, query_result)) => match row {
+                        Ok(Some(row)) => {
+                            this.query_result = Some(ResultSetStreamState::Idle(query_result));
+                            return Poll::Ready(Some(Ok(crate::from_row(row))));
+                        }
+                        Ok(None) => return Poll::Ready(None),
+                        Err(err) => return Poll::Ready(Some(Err(err))),
+                    },
+                    Poll::Pending => {
+                        this.query_result = Some(ResultSetStreamState::NextFut(fut));
+                        return Poll::Pending;
+                    }
+                },
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+impl<'a, 't: 'a, P> QueryResult<'a, 't, P>
+where
+    P: Protocol + Unpin,
+{
+    async fn setup_stream(
+        &mut self,
+    ) -> crate::Result<Option<(Option<OkPacket<'static>>, Arc<[Column]>)>> {
+        match self.conn.use_pending_result()? {
+            Some(PendingResult::Taken(meta)) => {
+                let meta = (*meta).clone();
+                self.skip_taken(meta).await?;
+            }
+            Some(_) => (),
+            None => return Ok(None),
+        }
+
+        let ok_packet = self.conn.last_ok_packet().cloned();
+        let columns = match self.conn.take_pending_result()? {
+            Some(meta) => meta.columns().clone(),
+            None => return Ok(None),
+        };
+
+        Ok(Some((ok_packet, columns)))
+    }
+
+    /// Returns a [`Stream`] for the current result set.
+    ///
+    /// The returned stream satisfies [`futures_util::TryStream`],
+    /// so you can use [`futures_util::TryStreamExt`] functions on it.
+    ///
+    /// # Behavior
+    ///
+    /// ## Conversion
+    ///
+    /// This stream will convert each row into `T` using [`FromRow`] implementation.
+    /// Please use the [`Row`] type for `T` to make this conversion infallible.
+    ///
+    /// ## Consumption
+    ///
+    /// The call to [`QueryResult::stream`] entails the consumption of the current result set,
+    /// practicly this means that the second call to [`QueryResult::stream`] will return
+    /// the next result set stream even if the stream returned from the first call wasn't
+    /// explicitly consumed:
+    ///
+    /// ```rust
+    /// # use mysql_async::test_misc::get_opts;
+    /// # #[tokio::main]
+    /// # async fn main() -> mysql_async::Result<()> {
+    /// # use mysql_async::*;
+    /// # use mysql_async::prelude::*;
+    /// # use futures_util::StreamExt;
+    /// let mut conn = Conn::new(get_opts()).await?;
+    ///
+    /// // This query result will contain two result sets.
+    /// let mut result = conn.query_iter("SELECT 1; SELECT 2;").await?;
+    ///
+    /// // The first result set stream is dropped here without being consumed,
+    /// let _ = result.stream::<u8>().await?;
+    /// // so it will be implicitly consumed here.
+    /// let mut stream = result.stream::<u8>().await?.expect("the second result set must be here");
+    /// assert_eq!(2_u8, stream.next().await.unwrap()?);
+    ///
+    /// # drop(stream); drop(result); conn.disconnect().await }
+    /// ```
+    ///
+    /// ## Errors
+    ///
+    /// Note, that [`QueryResult::stream`] may error if:
+    ///
+    /// - current result set contains an error,
+    /// - previously unconsumed result set stream contained an error.
+    ///
+    /// ```rust
+    /// # use mysql_async::test_misc::get_opts;
+    /// # #[tokio::main]
+    /// # async fn main() -> mysql_async::Result<()> {
+    /// # use mysql_async::*;
+    /// # use mysql_async::prelude::*;
+    /// # use futures_util::StreamExt;
+    /// let mut conn = Conn::new(get_opts()).await?;
+    ///
+    /// // The second result set of this query will contain an error.
+    /// let mut result = conn.query_iter("SELECT 1; SELECT FOO(); SELECT 2;").await?;
+    ///
+    /// // First result set stream is dropped here without being consumed,
+    /// let _ = result.stream::<Row>().await?;
+    /// // so it will be implicitly consumed on the second call to `QueryResult::stream`
+    /// // that will error complaining about unknown FOO
+    /// assert!(result.stream::<Row>().await.unwrap_err().to_string().contains("FOO"));
+    ///
+    /// # drop(result); conn.disconnect().await }
+    /// ```
+    pub fn stream<'r, T: Unpin + FromRow + Send + 'static>(
+        &'r mut self,
+    ) -> BoxFuture<'r, crate::Result<Option<ResultSetStream<'r, 'a, 't, T, P>>>> {
+        async move {
+            Ok(self
+                .setup_stream()
+                .await?
+                .map(
+                    move |(ok_packet, columns)| ResultSetStream::<'r, 'a, 't, T, P> {
+                        ok_packet,
+                        columns,
+                        query_result: Some(ResultSetStreamState::Idle(CowMut::Borrowed(self))),
+                        __from_row_type: PhantomData,
+                    },
+                ))
+        }
+        .boxed()
+    }
+
+    /// Owned version of the [`QueryResult::stream`].
+    ///
+    /// Returned stream will stop iteration on the first result set boundary.
+    ///
+    /// See also [`Query::stream`][query_stream], [`Queryable::query_stream`][queryable_query_stream],
+    /// [`Queryable::exec_stream`][queryable_exec_stream].
+    ///
+    /// The following example uses the [`Query::stream`][query_stream] function
+    /// that is based on the [`QueryResult::stream_and_drop`]:
+    ///
+    /// ```rust
+    /// # use mysql_async::test_misc::get_opts;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use mysql_async::*;
+    /// # use mysql_async::prelude::*;
+    /// # use futures_util::TryStreamExt;
+    /// let pool = Pool::new(get_opts());
+    /// let mut conn = pool.get_conn().await?;
+    ///
+    /// // This example uses the `Query::stream` function that is based on `QueryResult::stream_and_drop`:
+    /// let mut stream = "SELECT 1 UNION ALL SELECT 2".stream::<u8, _>(&mut conn).await?;
+    /// let rows = stream.try_collect::<Vec<_>>().await.unwrap();
+    /// assert_eq!(vec![1, 2], rows);
+    ///
+    /// // Only the first result set will go into the stream:
+    /// let mut stream = r"
+    ///     SELECT 'foo' UNION ALL SELECT 'bar';
+    ///     SELECT 'baz' UNION ALL SELECT 'quux';".stream::<String, _>(&mut conn).await?;
+    /// let rows = stream.try_collect::<Vec<_>>().await.unwrap();
+    /// assert_eq!(vec!["foo".to_owned(), "bar".to_owned()], rows);
+    ///
+    /// // We can also build a `'static` stream by giving away the connection:
+    /// let stream = "SELECT 2 UNION ALL SELECT 3".stream::<u8, _>(conn).await?;
+    /// // `tokio::spawn` requires `'static`
+    /// let handle = tokio::spawn(async move {
+    ///     stream.try_collect::<Vec<_>>().await.unwrap()
+    /// });
+    /// assert_eq!(vec![2, 3], handle.await?);
+    ///
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [queryable_query_stream]: crate::prelude::Queryable::query_stream
+    /// [queryable_exec_stream]: crate::prelude::Queryable::exec_stream
+    /// [query_stream]: crate::prelude::Query::stream
+    pub fn stream_and_drop<T: Unpin + FromRow + Send + 'static>(
+        mut self,
+    ) -> BoxFuture<'a, crate::Result<Option<ResultSetStream<'a, 'a, 't, T, P>>>> {
+        async move {
+            Ok(self
+                .setup_stream()
+                .await?
+                .map(|(ok_packet, columns)| ResultSetStream::<'a, 'a, 't, T, P> {
+                    ok_packet,
+                    columns,
+                    query_result: Some(ResultSetStreamState::Idle(CowMut::Owned(self))),
+                    __from_row_type: PhantomData,
+                }))
+        }
+        .boxed()
+    }
+}

--- a/src/queryable/query_result/tests.rs
+++ b/src/queryable/query_result/tests.rs
@@ -1,0 +1,251 @@
+#![cfg(test)]
+
+use futures_util::TryStreamExt;
+
+use crate::{from_row, prelude::*, test_misc::get_opts, Conn, Row, TxOpts};
+
+#[tokio::test]
+async fn should_stream_text_result_sets() -> crate::Result<()> {
+    const QUERY: &str = r"
+        SELECT 1;
+        SELECT 'foo' UNION ALL SELECT 'bar';
+        SELECT 3, 4 UNION ALL SELECT 5, 6;
+        SELECT FOO();
+        SELECT 3.14;
+    ";
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = QUERY.run(&mut conn).await?;
+
+    let stream = result.stream::<u8>().await?.unwrap();
+    assert_eq!(vec![1], stream.try_collect::<Vec<_>>().await?);
+
+    let _ = result.stream::<Row>().await?.unwrap();
+
+    let stream = result.stream::<(u8, u8)>().await?.unwrap();
+    assert_eq!(vec![(3, 4), (5, 6)], stream.try_collect::<Vec<_>>().await?);
+
+    let _ = result.stream::<Row>().await.unwrap_err();
+    assert!(result.stream::<Row>().await?.is_none());
+
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = QUERY.run(&mut conn).await?;
+
+    assert_eq!(vec![1], result.collect::<u8>().await?);
+
+    assert_eq!("foo", from_row::<String>(result.next().await?.unwrap()));
+    let _ = result.stream::<Row>().await?.unwrap();
+
+    assert_eq!((3_u8, 4_u8), from_row(result.next().await?.unwrap()));
+    assert_eq!(vec![(5, 6)], result.collect::<(u8, u8)>().await?);
+
+    result.collect::<Row>().await.unwrap_err();
+    assert!(result.stream::<Row>().await?.is_none());
+
+    conn.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropped_query_result_should_emit_errors_on_cleanup() -> super::Result<()> {
+    use crate::{Error::Server, ServerError};
+    let mut conn = Conn::new(get_opts()).await?;
+    conn.query_iter("SELECT '1'; BLABLA;").await?;
+    assert!(matches!(
+        conn.query_drop("DO 42;").await.unwrap_err(),
+        Server(ServerError { code: 1064, .. })
+    ));
+    conn.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_try_collect() -> super::Result<()> {
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = conn
+        .query_iter(
+            r"SELECT 'hello', 123
+                UNION ALL
+                SELECT 'world', 'bar'
+                UNION ALL
+                SELECT 'hello', 123
+            ",
+        )
+        .await?;
+    let mut rows = result.try_collect::<(String, u8)>().await?;
+    assert!(rows.pop().unwrap().is_ok());
+    assert!(rows.pop().unwrap().is_err());
+    assert!(rows.pop().unwrap().is_ok());
+    result.drop_result().await?;
+    conn.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_try_collect_and_drop() -> super::Result<()> {
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut rows = conn
+        .query_iter(
+            r"SELECT 'hello', 123
+                UNION ALL
+                SELECT 'world', 'bar'
+                UNION ALL
+                SELECT 'hello', 123;
+                SELECT 'foo', 255;
+            ",
+        )
+        .await?
+        .try_collect_and_drop::<(String, u8)>()
+        .await?;
+    assert!(rows.pop().unwrap().is_ok());
+    assert!(rows.pop().unwrap().is_err());
+    assert!(rows.pop().unwrap().is_ok());
+    conn.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_handle_mutliresult_set() -> super::Result<()> {
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = conn
+        .query_iter(
+            r"SELECT 'hello', 123
+                UNION ALL
+                SELECT 'world', 231;
+                SELECT 'foo', 255;
+            ",
+        )
+        .await?;
+    let rows_1 = result.collect::<(String, u8)>().await?;
+    let rows_2 = result.collect_and_drop().await?;
+    conn.disconnect().await?;
+
+    assert_eq!((String::from("hello"), 123), rows_1[0]);
+    assert_eq!((String::from("world"), 231), rows_1[1]);
+    assert_eq!((String::from("foo"), 255), rows_2[0]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_map_resultset() -> super::Result<()> {
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = conn
+        .query_iter(
+            r"
+                SELECT 'hello', 123
+                UNION ALL
+                SELECT 'world', 231;
+                SELECT 'foo', 255;
+            ",
+        )
+        .await?;
+
+    let rows_1 = result.map(|row| from_row::<(String, u8)>(row)).await?;
+    let rows_2 = result.map_and_drop(from_row).await?;
+    conn.disconnect().await?;
+
+    assert_eq!((String::from("hello"), 123), rows_1[0]);
+    assert_eq!((String::from("world"), 231), rows_1[1]);
+    assert_eq!((String::from("foo"), 255), rows_2[0]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_reduce_resultset() -> super::Result<()> {
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = conn
+        .query_iter(
+            r"SELECT 5
+                UNION ALL
+                SELECT 6;
+                SELECT 7;",
+        )
+        .await?;
+    let reduced = result
+        .reduce(0, |mut acc, row| {
+            acc += from_row::<i32>(row);
+            acc
+        })
+        .await?;
+    let rows_2 = result.collect_and_drop::<i32>().await?;
+    conn.disconnect().await?;
+    assert_eq!(11, reduced);
+    assert_eq!(7, rows_2[0]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_handle_multi_result_sets_where_some_results_have_no_output() -> super::Result<()> {
+    const QUERY: &str = r"SELECT 1;
+        UPDATE time_zone SET Time_zone_id = 1 WHERE Time_zone_id = 1;
+        SELECT 2;
+        SELECT 3;
+        UPDATE time_zone SET Time_zone_id = 1 WHERE Time_zone_id = 1;
+        UPDATE time_zone SET Time_zone_id = 1 WHERE Time_zone_id = 1;
+        SELECT 4;";
+
+    let mut c = Conn::new(get_opts()).await?;
+    c.query_drop("CREATE TEMPORARY TABLE time_zone (Time_zone_id INT)")
+        .await
+        .unwrap();
+    let mut t = c.start_transaction(TxOpts::new()).await?;
+    t.query_drop(QUERY).await?;
+    let r = t.query_iter(QUERY).await?;
+    let out = r.collect_and_drop::<u8>().await?;
+    assert_eq!(vec![1], out);
+    let r = t.query_iter(QUERY).await?;
+    r.for_each_and_drop(|x| assert_eq!(from_row::<u8>(x), 1))
+        .await?;
+    let r = t.query_iter(QUERY).await?;
+    let out = r.map_and_drop(|row| from_row::<u8>(row)).await?;
+    assert_eq!(vec![1], out);
+    let r = t.query_iter(QUERY).await?;
+    let out = r
+        .reduce_and_drop(0u8, |acc, x| acc + from_row::<u8>(x))
+        .await?;
+    assert_eq!(1, out);
+    t.query_drop(QUERY).await?;
+    t.commit().await?;
+    let result = c.exec_first("SELECT 1", ()).await?;
+    c.disconnect().await?;
+    assert_eq!(result, Some(1_u8));
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_iterate_over_resultset() -> super::Result<()> {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    let acc = Arc::new(AtomicUsize::new(0));
+
+    let mut conn = Conn::new(get_opts()).await?;
+    let mut result = conn
+        .query_iter(
+            r"SELECT 2
+                UNION ALL
+                SELECT 3;
+                SELECT 5;",
+        )
+        .await?;
+    result
+        .for_each({
+            let acc = acc.clone();
+            move |row| {
+                acc.fetch_add(from_row::<usize>(row), Ordering::SeqCst);
+            }
+        })
+        .await?;
+    result
+        .for_each_and_drop({
+            let acc = acc.clone();
+            move |row| {
+                acc.fetch_add(from_row::<usize>(row), Ordering::SeqCst);
+            }
+        })
+        .await?;
+    conn.disconnect().await?;
+    assert_eq!(acc.load(Ordering::SeqCst), 10);
+    Ok(())
+}


### PR DESCRIPTION
This PR adds:

* `QueryResult::stream`
* `QueryResult::stream_and_drop`
* `Query::stream`
* `Queryable::query_stream`
* `Queryable::exec_stream`