### PR TITLE
cancel connection when acquired by BinLogStream

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1032,7 +1032,7 @@ impl Conn {
 
     pub async fn get_binlog_stream(mut self, request: BinlogRequest<'_>) -> Result<BinlogStream> {
         // We'll disconnect this connection from a pool before requesting the binlog.
-        self.inner.pool = None;
+        self.inner.pool.take().map(|pool|pool.cancel_connection());
         self.request_binlog(request).await?;
 
         Ok(BinlogStream::new(self))

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1032,7 +1032,7 @@ impl Conn {
 
     pub async fn get_binlog_stream(mut self, request: BinlogRequest<'_>) -> Result<BinlogStream> {
         // We'll disconnect this connection from a pool before requesting the binlog.
-        self.inner.pool.take().map(|pool|pool.cancel_connection());
+        self.inner.pool.take().map(|pool| pool.cancel_connection());
         self.request_binlog(request).await?;
 
         Ok(BinlogStream::new(self))

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -221,7 +221,7 @@ impl Pool {
     ///
     /// Decreases the exist counter since a broken or dropped connection should not count towards
     /// the total.
-    fn cancel_connection(&self) {
+    pub(super) fn cancel_connection(&self) {
         let mut exchange = self.inner.exchange.lock().unwrap();
         exchange.exist -= 1;
         // we just enabled the creation of a new connection!


### PR DESCRIPTION
Currently when a BinLogStream is acquired it doesn't decrease the counter on the Pool, which causes the pool panic when it is dropped