### PR TITLE
BinlogStream's Conn can be closed and returned to Pool

### DIFF
--- a/src/io/read_packet.rs
+++ b/src/io/read_packet.rs
@@ -20,7 +20,7 @@ use crate::{buffer_pool::PooledBuf, connection_like::Connection, error::IoError,
 /// Reads a packet.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ReadPacket<'a, 't>(Connection<'a, 't>);
+pub struct ReadPacket<'a, 't>(pub(crate) Connection<'a, 't>);
 
 impl<'a, 't> ReadPacket<'a, 't> {
     pub(crate) fn new<T: Into<Connection<'a, 't>>>(conn: T) -> Self {


### PR DESCRIPTION
After getting a connection from a pool, and using that connection to get a binlog stream, the pool cannot be disconnected. Why? Because the pool counts the connections as still alive (the pool never decreases the count, even after the binlog stream and its connection are disconnected and dropped). 

As detailed [here](https://github.com/blackbeam/mysql_async/pull/200#issuecomment-1134051300), I believe it's best to let the binlog connection remain part of the pool, and then returning the connection slot to the pool once the binlog stream goes out of scope and is dropped. 

This PR makes it possible to close a binlog stream's connection, and if the stream belonged to a pool, it returns said connection back to the pool. Both disconnecting the stream, and the return of the connection are tested.

Importantly, this PR adds `BinlogStream::close` to the crate's public API (previously, the Binlog Stream's connection would just hang until it timed out and it was not possible to disconnect the stream's connection). 