### PR TITLE
Accept either bytes or strings for queries

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1382,8 +1382,8 @@ mod test {
             .stmt_cache_ref()
             .iter()
             .map(|item| item.1.query.0.as_ref())
-            .collect::<Vec<&str>>();
-        assert_eq!(order, &["DO 6", "DO 5", "DO 3"]);
+            .collect::<Vec<&[u8]>>();
+        assert_eq!(order, &[b"DO 6", b"DO 5", b"DO 3"]);
         conn.disconnect().await?;
         Ok(())
     }

--- a/src/conn/routines/prepare.rs
+++ b/src/conn/routines/prepare.rs
@@ -11,13 +11,13 @@ use super::Routine;
 /// A routine that performs `COM_STMT_PREPARE`.
 #[derive(Debug, Clone)]
 pub struct PrepareRoutine {
-    query: Arc<str>,
+    query: Arc<[u8]>,
 }
 
 impl PrepareRoutine {
-    pub fn new(raw_query: Cow<'_, str>) -> Self {
+    pub fn new(raw_query: Cow<'_, [u8]>) -> Self {
         Self {
-            query: raw_query.into_owned().into_boxed_str().into(),
+            query: raw_query.into_owned().into_boxed_slice().into(),
         }
     }
 }
@@ -25,7 +25,7 @@ impl PrepareRoutine {
 impl Routine<Arc<StmtInner>> for PrepareRoutine {
     fn call<'a>(&'a mut self, conn: &'a mut Conn) -> BoxFuture<'a, crate::Result<Arc<StmtInner>>> {
         async move {
-            conn.write_command_data(Command::COM_STMT_PREPARE, self.query.as_bytes())
+            conn.write_command_data(Command::COM_STMT_PREPARE, &self.query)
                 .await?;
 
             let packet = conn.read_packet().await?;

--- a/src/conn/stmt_cache.rs
+++ b/src/conn/stmt_cache.rs
@@ -19,16 +19,16 @@ use std::{
 use crate::queryable::stmt::StmtInner;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct QueryString(pub Arc<str>);
+pub struct QueryString(pub Arc<[u8]>);
 
-impl Borrow<str> for QueryString {
-    fn borrow(&self) -> &str {
+impl Borrow<[u8]> for QueryString {
+    fn borrow(&self) -> &[u8] {
         &*self.0.as_ref()
     }
 }
 
-impl PartialEq<str> for QueryString {
-    fn eq(&self, other: &str) -> bool {
+impl PartialEq<[u8]> for QueryString {
+    fn eq(&self, other: &[u8]) -> bool {
         &*self.0.as_ref() == other
     }
 }
@@ -68,7 +68,7 @@ impl StmtCache {
         }
     }
 
-    pub fn put(&mut self, query: Arc<str>, stmt: Arc<StmtInner>) -> Option<Arc<StmtInner>> {
+    pub fn put(&mut self, query: Arc<[u8]>, stmt: Arc<StmtInner>) -> Option<Arc<StmtInner>> {
         if self.cap == 0 {
             return None;
         }
@@ -95,7 +95,7 @@ impl StmtCache {
 
     pub fn remove(&mut self, id: u32) {
         if let Some(entry) = self.cache.pop(&id) {
-            self.query_map.remove::<str>(entry.query.borrow());
+            self.query_map.remove::<[u8]>(entry.query.borrow());
         }
     }
 
@@ -135,7 +135,7 @@ impl super::Conn {
     /// Returns statement, if cached.
     ///
     /// `raw_query` is the query with `?` placeholders (not with `:<name>` placeholders).
-    pub(crate) fn get_cached_stmt(&mut self, raw_query: &str) -> Option<Arc<StmtInner>> {
+    pub(crate) fn get_cached_stmt(&mut self, raw_query: &[u8]) -> Option<Arc<StmtInner>> {
         self.stmt_cache_mut()
             .by_query(raw_query)
             .map(|entry| entry.stmt.clone())

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,8 +107,8 @@ pub enum DriverError {
     #[error("Error converting from mysql row.")]
     FromRow { row: Row },
 
-    #[error("Missing named parameter `{}'.", name)]
-    MissingNamedParam { name: String },
+    #[error("Missing named parameter `{}'.", String::from_utf8_lossy(&name))]
+    MissingNamedParam { name: Vec<u8> },
 
     #[error("Named and positional parameters mixed in one statement.")]
     MixedParams,

--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -22,6 +22,8 @@ use crate::{
     Column, Params,
 };
 
+use super::AsQuery;
+
 /// Result of a `StatementLike::to_statement` call.
 pub enum ToStatementResult<'a> {
     /// Statement is immediately available.
@@ -37,12 +39,12 @@ pub trait StatementLike: Send + Sync {
         Self: 'a;
 }
 
-fn to_statement_move<'a, T: AsRef<str> + Send + Sync + 'a>(
+fn to_statement_move<'a, T: AsQuery + 'a>(
     stmt: T,
     conn: &'a mut crate::Conn,
 ) -> ToStatementResult<'a> {
     let fut = async move {
-        let (named_params, raw_query) = parse_named_params(stmt.as_ref())?;
+        let (named_params, raw_query) = parse_named_params(stmt.as_query())?;
         let inner_stmt = match conn.get_cached_stmt(&*raw_query) {
             Some(inner_stmt) => inner_stmt,
             None => conn.prepare_statement(raw_query).await?,
@@ -119,7 +121,7 @@ impl<T: StatementLike + Clone> StatementLike for &'_ T {
 /// Statement data.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StmtInner {
-    pub(crate) raw_query: Arc<str>,
+    pub(crate) raw_query: Arc<[u8]>,
     columns: Option<Box<[Column]>>,
     params: Option<Box<[Column]>>,
     stmt_packet: StmtPacket,
@@ -130,7 +132,7 @@ impl StmtInner {
     pub(crate) fn from_payload(
         pld: &[u8],
         connection_id: u32,
-        raw_query: Arc<str>,
+        raw_query: Arc<[u8]>,
     ) -> std::io::Result<Self> {
         let stmt_packet = ParseBuf(pld).parse(())?;
 
@@ -192,11 +194,11 @@ impl StmtInner {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Statement {
     pub(crate) inner: Arc<StmtInner>,
-    pub(crate) named_params: Option<Vec<String>>,
+    pub(crate) named_params: Option<Vec<Vec<u8>>>,
 }
 
 impl Statement {
-    pub(crate) fn new(inner: Arc<StmtInner>, named_params: Option<Vec<String>>) -> Self {
+    pub(crate) fn new(inner: Arc<StmtInner>, named_params: Option<Vec<Vec<u8>>>) -> Self {
         Self {
             inner,
             named_params,
@@ -275,7 +277,7 @@ impl crate::Conn {
     /// Low-level helper, that prepares the given statement.
     ///
     /// `raw_query` is a query with `?` placeholders (if any).
-    async fn prepare_statement(&mut self, raw_query: Cow<'_, str>) -> Result<Arc<StmtInner>> {
+    async fn prepare_statement(&mut self, raw_query: Cow<'_, [u8]>) -> Result<Arc<StmtInner>> {
         let inner_stmt = self.routine(PrepareRoutine::new(raw_query)).await?;
 
         if let Some(old_stmt) = self.cache_stmt(&inner_stmt) {


### PR DESCRIPTION
As discussed in #194, MySQL actually accepts arbitrary sequences of
bytes, not just utf-8 strings, as queries, but this crate is limited to
only working with types that impl AsRef<str>. To allow sending arbitrary
byte slices as queries this commit, which goes along with and requires
https://github.com/blackbeam/rust_mysql_common/pull/64, introduces a new
`AsQuery` trait, which is impl'd for all of the standard library types
that either impl AsRef<str> or AsRef<[u8]>, and uses that trait in place
of `AsRef<str>` for all query methods, going on down the chain to error
types, internal cache structures, etc. as well.