### PR TITLE
Accept either bytes or strings for queryes (updated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-sink = "0.3"
 lazy_static = "1"
 lru = "0.7.0"
 mio = { version = "0.8.0", features = ["os-poll", "net"] }
-mysql_common = { version = "0.28.0", default-features = false }
+mysql_common = { version = "0.29.0", default-features = false }
 native-tls = "0.2"
 once_cell = "1.7.2"
 pem = "1.0.1"

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1382,8 +1382,8 @@ mod test {
             .stmt_cache_ref()
             .iter()
             .map(|item| item.1.query.0.as_ref())
-            .collect::<Vec<&str>>();
-        assert_eq!(order, &["DO 6", "DO 5", "DO 3"]);
+            .collect::<Vec<&[u8]>>();
+        assert_eq!(order, &[b"DO 6", b"DO 5", b"DO 3"]);
         conn.disconnect().await?;
         Ok(())
     }

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -397,7 +397,7 @@ mod test {
 
             // now we'll kill connections..
             for id in ids {
-                master.query_drop(&format!("KILL {}", id)).await?;
+                master.query_drop(format!("KILL {}", id)).await?;
             }
 
             // now check, that they're still in the pool..

--- a/src/conn/routines/prepare.rs
+++ b/src/conn/routines/prepare.rs
@@ -11,13 +11,13 @@ use super::Routine;
 /// A routine that performs `COM_STMT_PREPARE`.
 #[derive(Debug, Clone)]
 pub struct PrepareRoutine {
-    query: Arc<str>,
+    query: Arc<[u8]>,
 }
 
 impl PrepareRoutine {
-    pub fn new(raw_query: Cow<'_, str>) -> Self {
+    pub fn new(raw_query: Cow<'_, [u8]>) -> Self {
         Self {
-            query: raw_query.into_owned().into_boxed_str().into(),
+            query: raw_query.into_owned().into_boxed_slice().into(),
         }
     }
 }
@@ -25,7 +25,7 @@ impl PrepareRoutine {
 impl Routine<Arc<StmtInner>> for PrepareRoutine {
     fn call<'a>(&'a mut self, conn: &'a mut Conn) -> BoxFuture<'a, crate::Result<Arc<StmtInner>>> {
         async move {
-            conn.write_command_data(Command::COM_STMT_PREPARE, self.query.as_bytes())
+            conn.write_command_data(Command::COM_STMT_PREPARE, &self.query)
                 .await?;
 
             let packet = conn.read_packet().await?;

--- a/src/conn/stmt_cache.rs
+++ b/src/conn/stmt_cache.rs
@@ -19,16 +19,16 @@ use std::{
 use crate::queryable::stmt::StmtInner;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct QueryString(pub Arc<str>);
+pub struct QueryString(pub Arc<[u8]>);
 
-impl Borrow<str> for QueryString {
-    fn borrow(&self) -> &str {
+impl Borrow<[u8]> for QueryString {
+    fn borrow(&self) -> &[u8] {
         &*self.0.as_ref()
     }
 }
 
-impl PartialEq<str> for QueryString {
-    fn eq(&self, other: &str) -> bool {
+impl PartialEq<[u8]> for QueryString {
+    fn eq(&self, other: &[u8]) -> bool {
         &*self.0.as_ref() == other
     }
 }
@@ -68,7 +68,7 @@ impl StmtCache {
         }
     }
 
-    pub fn put(&mut self, query: Arc<str>, stmt: Arc<StmtInner>) -> Option<Arc<StmtInner>> {
+    pub fn put(&mut self, query: Arc<[u8]>, stmt: Arc<StmtInner>) -> Option<Arc<StmtInner>> {
         if self.cap == 0 {
             return None;
         }
@@ -95,7 +95,7 @@ impl StmtCache {
 
     pub fn remove(&mut self, id: u32) {
         if let Some(entry) = self.cache.pop(&id) {
-            self.query_map.remove::<str>(entry.query.borrow());
+            self.query_map.remove::<[u8]>(entry.query.borrow());
         }
     }
 
@@ -135,7 +135,7 @@ impl super::Conn {
     /// Returns statement, if cached.
     ///
     /// `raw_query` is the query with `?` placeholders (not with `:<name>` placeholders).
-    pub(crate) fn get_cached_stmt(&mut self, raw_query: &str) -> Option<Arc<StmtInner>> {
+    pub(crate) fn get_cached_stmt(&mut self, raw_query: &[u8]) -> Option<Arc<StmtInner>> {
         self.stmt_cache_mut()
             .by_query(raw_query)
             .map(|entry| entry.stmt.clone())

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,8 +107,8 @@ pub enum DriverError {
     #[error("Error converting from mysql row.")]
     FromRow { row: Row },
 
-    #[error("Missing named parameter `{}'.", name)]
-    MissingNamedParam { name: String },
+    #[error("Missing named parameter `{}'.", String::from_utf8_lossy(&name))]
+    MissingNamedParam { name: Vec<u8> },
 
     #[error("Named and positional parameters mixed in one statement.")]
     MixedParams,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,8 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::local_infile_handler::GlobalHandler;
     #[doc(inline)]
+    pub use crate::query::AsQuery;
+    #[doc(inline)]
     pub use crate::query::{BatchQuery, Query, WithParams};
     #[doc(inline)]
     pub use crate::queryable::Queryable;

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,6 +6,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use std::borrow::Cow;
+
 use futures_util::FutureExt;
 
 use crate::{
@@ -21,20 +23,20 @@ use crate::{
 /// `Cow<str>`, but also all types that can be treated as a slice of bytes (such as `Vec<u8>` and
 /// `&[u8]`), since MySQL does not require queries to be valid UTF-8.
 pub trait AsQuery: Send + Sync {
-    fn as_query(&self) -> &[u8];
+    fn as_query(&self) -> Cow<'_, [u8]>;
 }
 
 impl AsQuery for &'_ [u8] {
-    fn as_query(&self) -> &[u8] {
-        self
+    fn as_query(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self)
     }
 }
 
 macro_rules! impl_as_query_as_ref {
     ($type: ty) => {
         impl AsQuery for $type {
-            fn as_query(&self) -> &[u8] {
-                self.as_ref()
+            fn as_query(&self) -> Cow<'_, [u8]> {
+                Cow::Borrowed(self.as_ref())
             }
         }
     };
@@ -43,14 +45,14 @@ macro_rules! impl_as_query_as_ref {
 impl_as_query_as_ref!(Vec<u8>);
 impl_as_query_as_ref!(&Vec<u8>);
 impl_as_query_as_ref!(Box<[u8]>);
-impl_as_query_as_ref!(std::borrow::Cow<'_, [u8]>);
+impl_as_query_as_ref!(Cow<'_, [u8]>);
 impl_as_query_as_ref!(std::sync::Arc<[u8]>);
 
 macro_rules! impl_as_query_as_bytes {
     ($type: ty) => {
         impl AsQuery for $type {
-            fn as_query(&self) -> &[u8] {
-                self.as_bytes()
+            fn as_query(&self) -> Cow<'_, [u8]> {
+                Cow::Borrowed(self.as_bytes())
             }
         }
     };
@@ -60,7 +62,7 @@ impl_as_query_as_bytes!(String);
 impl_as_query_as_bytes!(&String);
 impl_as_query_as_bytes!(&str);
 impl_as_query_as_bytes!(Box<str>);
-impl_as_query_as_bytes!(std::borrow::Cow<'_, str>);
+impl_as_query_as_bytes!(Cow<'_, str>);
 impl_as_query_as_bytes!(std::sync::Arc<str>);
 
 /// MySql text query.

--- a/src/queryable/mod.rs
+++ b/src/queryable/mod.rs
@@ -105,7 +105,8 @@ impl Conn {
     where
         Q: AsQuery + 'a,
     {
-        self.routine(QueryRoutine::new(query.as_query())).await
+        self.routine(QueryRoutine::new(query.as_query().as_ref()))
+            .await
     }
 }
 
@@ -454,7 +455,8 @@ impl Queryable for Conn {
         Q: AsQuery + 'a,
     {
         async move {
-            self.routine(QueryRoutine::new(query.as_query())).await?;
+            self.routine(QueryRoutine::new(query.as_query().as_ref()))
+                .await?;
             Ok(QueryResult::new(self))
         }
         .boxed()

--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -22,6 +22,8 @@ use crate::{
     Column, Params,
 };
 
+use super::AsQuery;
+
 /// Result of a `StatementLike::to_statement` call.
 pub enum ToStatementResult<'a> {
     /// Statement is immediately available.
@@ -37,12 +39,12 @@ pub trait StatementLike: Send + Sync {
         Self: 'a;
 }
 
-fn to_statement_move<'a, T: AsRef<str> + Send + Sync + 'a>(
+fn to_statement_move<'a, T: AsQuery + 'a>(
     stmt: T,
     conn: &'a mut crate::Conn,
 ) -> ToStatementResult<'a> {
     let fut = async move {
-        let (named_params, raw_query) = parse_named_params(stmt.as_ref())?;
+        let (named_params, raw_query) = parse_named_params(stmt.as_query())?;
         let inner_stmt = match conn.get_cached_stmt(&*raw_query) {
             Some(inner_stmt) => inner_stmt,
             None => conn.prepare_statement(raw_query).await?,
@@ -119,7 +121,7 @@ impl<T: StatementLike + Clone> StatementLike for &'_ T {
 /// Statement data.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StmtInner {
-    pub(crate) raw_query: Arc<str>,
+    pub(crate) raw_query: Arc<[u8]>,
     columns: Option<Box<[Column]>>,
     params: Option<Box<[Column]>>,
     stmt_packet: StmtPacket,
@@ -130,7 +132,7 @@ impl StmtInner {
     pub(crate) fn from_payload(
         pld: &[u8],
         connection_id: u32,
-        raw_query: Arc<str>,
+        raw_query: Arc<[u8]>,
     ) -> std::io::Result<Self> {
         let stmt_packet = ParseBuf(pld).parse(())?;
 
@@ -192,11 +194,11 @@ impl StmtInner {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Statement {
     pub(crate) inner: Arc<StmtInner>,
-    pub(crate) named_params: Option<Vec<String>>,
+    pub(crate) named_params: Option<Vec<Vec<u8>>>,
 }
 
 impl Statement {
-    pub(crate) fn new(inner: Arc<StmtInner>, named_params: Option<Vec<String>>) -> Self {
+    pub(crate) fn new(inner: Arc<StmtInner>, named_params: Option<Vec<Vec<u8>>>) -> Self {
         Self {
             inner,
             named_params,
@@ -275,7 +277,7 @@ impl crate::Conn {
     /// Low-level helper, that prepares the given statement.
     ///
     /// `raw_query` is a query with `?` placeholders (if any).
-    async fn prepare_statement(&mut self, raw_query: Cow<'_, str>) -> Result<Arc<StmtInner>> {
+    async fn prepare_statement(&mut self, raw_query: Cow<'_, [u8]>) -> Result<Arc<StmtInner>> {
         let inner_stmt = self.routine(PrepareRoutine::new(raw_query)).await?;
 
         if let Some(old_stmt) = self.cache_stmt(&inner_stmt) {

--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -44,7 +44,8 @@ fn to_statement_move<'a, T: AsQuery + 'a>(
     conn: &'a mut crate::Conn,
 ) -> ToStatementResult<'a> {
     let fut = async move {
-        let (named_params, raw_query) = parse_named_params(stmt.as_query())?;
+        let query = stmt.as_query();
+        let (named_params, raw_query) = parse_named_params(query.as_ref())?;
         let inner_stmt = match conn.get_cached_stmt(&*raw_query) {
             Some(inner_stmt) => inner_stmt,
             None => conn.prepare_statement(raw_query).await?,


### PR DESCRIPTION
(see #203)

@glittershark, created because I'm unable to push directly into your fork branch for some reason 🤔

Among reexporting `AsQuery` and bumping `mysql_common`, this PR alters `AsQuery::as_query` to return `Cow<'_, [u8]>` – this is to be query-builder friendly.

I'll wait for your feedback, but will merge and publish within few hours (because I must to).