### PR TITLE
Relax prep() to take impl AsQuery

### DIFF
--- a/src/queryable/mod.rs
+++ b/src/queryable/mod.rs
@@ -135,7 +135,7 @@ pub trait Queryable: Send {
     /// [stmt_cache_size]: crate::Opts::stmt_cache_size
     fn prep<'a, Q>(&'a mut self, query: Q) -> BoxFuture<'a, Statement>
     where
-        Q: AsRef<str> + Sync + Send + 'a;
+        Q: AsQuery + 'a;
 
     /// Closes the given statement.
     ///
@@ -464,9 +464,9 @@ impl Queryable for Conn {
 
     fn prep<'a, Q>(&'a mut self, query: Q) -> BoxFuture<'a, Statement>
     where
-        Q: AsRef<str> + Sync + Send + 'a,
+        Q: AsQuery + 'a,
     {
-        async move { self.get_statement(query.as_ref()).await }.boxed()
+        async move { self.get_statement(query.as_query()).await }.boxed()
     }
 
     fn close(&mut self, stmt: Statement) -> BoxFuture<'_, ()> {
@@ -533,7 +533,7 @@ impl Queryable for Transaction<'_> {
 
     fn prep<'a, Q>(&'a mut self, query: Q) -> BoxFuture<'a, Statement>
     where
-        Q: AsRef<str> + Sync + Send + 'a,
+        Q: AsQuery + 'a,
     {
         self.0.prep(query)
     }

--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -101,6 +101,51 @@ impl StatementLike for Arc<str> {
     }
 }
 
+impl StatementLike for Cow<'_, [u8]> {
+    fn to_statement<'a>(self, conn: &'a mut crate::Conn) -> ToStatementResult<'a>
+    where
+        Self: 'a,
+    {
+        to_statement_move(self, conn)
+    }
+}
+
+impl StatementLike for &'_ [u8] {
+    fn to_statement<'a>(self, conn: &'a mut crate::Conn) -> ToStatementResult<'a>
+    where
+        Self: 'a,
+    {
+        to_statement_move(self, conn)
+    }
+}
+
+impl StatementLike for Vec<u8> {
+    fn to_statement<'a>(self, conn: &'a mut crate::Conn) -> ToStatementResult<'a>
+    where
+        Self: 'a,
+    {
+        to_statement_move(self, conn)
+    }
+}
+
+impl StatementLike for Box<[u8]> {
+    fn to_statement<'a>(self, conn: &'a mut crate::Conn) -> ToStatementResult<'a>
+    where
+        Self: 'a,
+    {
+        to_statement_move(self, conn)
+    }
+}
+
+impl StatementLike for Arc<[u8]> {
+    fn to_statement<'a>(self, conn: &'a mut crate::Conn) -> ToStatementResult<'a>
+    where
+        Self: 'a,
+    {
+        to_statement_move(self, conn)
+    }
+}
+
 impl StatementLike for Statement {
     fn to_statement<'a>(self, _conn: &'a mut crate::Conn) -> ToStatementResult<'static>
     where


### PR DESCRIPTION
This was missed in the refactor of everything else to use AsQuery
instead of `AsRef<str> + Send + Sync`