### PR TITLE
Record errors from routines in tracing spans

### DIFF
--- a/src/conn/routines/exec.rs
+++ b/src/conn/routines/exec.rs
@@ -104,7 +104,13 @@ impl Routine<()> for ExecRoutine<'_> {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = fut.instrument(span);
+        let fut = async {
+            fut.await.or_else(|e| {
+                tracing::error!(error = %e);
+                Err(e)
+            })
+        }
+        .instrument(span);
 
         fut.boxed()
     }

--- a/src/conn/routines/exec.rs
+++ b/src/conn/routines/exec.rs
@@ -4,7 +4,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use mysql_common::{packets::ComStmtExecuteRequestBuilder, params::Params};
 #[cfg(feature = "tracing")]
-use tracing::{field, info_span, Instrument, Level, Span};
+use tracing::{field, info_span, Level, Span};
 
 use crate::{BinaryProtocol, Conn, DriverError, Statement};
 
@@ -104,13 +104,7 @@ impl Routine<()> for ExecRoutine<'_> {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = async {
-            fut.await.or_else(|e| {
-                tracing::error!(error = %e);
-                Err(e)
-            })
-        }
-        .instrument(span);
+        let fut = instrument_result!(fut, span);
 
         fut.boxed()
     }

--- a/src/conn/routines/next_set.rs
+++ b/src/conn/routines/next_set.rs
@@ -36,7 +36,13 @@ where
         };
 
         #[cfg(feature = "tracing")]
-        let fut = fut.instrument(span);
+        let fut = async {
+            fut.await.or_else(|e| {
+                tracing::error!(error = %e);
+                Err(e)
+            })
+        }
+        .instrument(span);
 
         fut.boxed()
     }

--- a/src/conn/routines/next_set.rs
+++ b/src/conn/routines/next_set.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 #[cfg(feature = "tracing")]
-use tracing::{debug_span, Instrument};
+use tracing::debug_span;
 
 use crate::{queryable::Protocol, Conn};
 
@@ -36,13 +36,7 @@ where
         };
 
         #[cfg(feature = "tracing")]
-        let fut = async {
-            fut.await.or_else(|e| {
-                tracing::error!(error = %e);
-                Err(e)
-            })
-        }
-        .instrument(span);
+        let fut = instrument_result!(fut, span);
 
         fut.boxed()
     }

--- a/src/conn/routines/ping.rs
+++ b/src/conn/routines/ping.rs
@@ -24,7 +24,13 @@ impl Routine<()> for PingRoutine {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = fut.instrument(span);
+        let fut = async {
+            fut.await.or_else(|e| {
+                tracing::error!(error = %e);
+                Err(e)
+            })
+        }
+        .instrument(span);
 
         fut.boxed()
     }

--- a/src/conn/routines/ping.rs
+++ b/src/conn/routines/ping.rs
@@ -2,7 +2,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use mysql_common::constants::Command;
 #[cfg(feature = "tracing")]
-use tracing::{debug_span, Instrument};
+use tracing::debug_span;
 
 use crate::Conn;
 
@@ -24,13 +24,7 @@ impl Routine<()> for PingRoutine {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = async {
-            fut.await.or_else(|e| {
-                tracing::error!(error = %e);
-                Err(e)
-            })
-        }
-        .instrument(span);
+        let fut = instrument_result!(fut, span);
 
         fut.boxed()
     }

--- a/src/conn/routines/prepare.rs
+++ b/src/conn/routines/prepare.rs
@@ -4,7 +4,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use mysql_common::constants::Command;
 #[cfg(feature = "tracing")]
-use tracing::{field, info_span, Instrument, Level, Span};
+use tracing::{field, info_span, Level, Span};
 
 use crate::{queryable::stmt::StmtInner, Conn};
 
@@ -66,13 +66,7 @@ impl Routine<Arc<StmtInner>> for PrepareRoutine {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = async {
-            fut.await.or_else(|e| {
-                tracing::error!(error = %e);
-                Err(e)
-            })
-        }
-        .instrument(span);
+        let fut = instrument_result!(fut, span);
 
         fut.boxed()
     }

--- a/src/conn/routines/query.rs
+++ b/src/conn/routines/query.rs
@@ -4,7 +4,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use mysql_common::constants::Command;
 #[cfg(feature = "tracing")]
-use tracing::{field, span_enabled, Instrument, Level};
+use tracing::{field, span_enabled, Level};
 
 use crate::tracing_utils::TracingLevel;
 use crate::{Conn, TextProtocol};
@@ -54,13 +54,7 @@ impl<L: TracingLevel> Routine<()> for QueryRoutine<'_, L> {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = async {
-            fut.await.or_else(|e| {
-                tracing::error!(error = %e);
-                Err(e)
-            })
-        }
-        .instrument(span);
+        let fut = instrument_result!(fut, span);
 
         fut.boxed()
     }

--- a/src/conn/routines/query.rs
+++ b/src/conn/routines/query.rs
@@ -54,7 +54,13 @@ impl<L: TracingLevel> Routine<()> for QueryRoutine<'_, L> {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = fut.instrument(span);
+        let fut = async {
+            fut.await.or_else(|e| {
+                tracing::error!(error = %e);
+                Err(e)
+            })
+        }
+        .instrument(span);
 
         fut.boxed()
     }

--- a/src/conn/routines/reset.rs
+++ b/src/conn/routines/reset.rs
@@ -2,7 +2,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use mysql_common::constants::Command;
 #[cfg(feature = "tracing")]
-use tracing::{debug_span, Instrument};
+use tracing::debug_span;
 
 use crate::Conn;
 
@@ -25,13 +25,7 @@ impl Routine<()> for ResetRoutine {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = async {
-            fut.await.or_else(|e| {
-                tracing::error!(error = %e);
-                Err(e)
-            })
-        }
-        .instrument(span);
+        let fut = instrument_result!(fut, span);
 
         fut.boxed()
     }

--- a/src/conn/routines/reset.rs
+++ b/src/conn/routines/reset.rs
@@ -25,7 +25,13 @@ impl Routine<()> for ResetRoutine {
         };
 
         #[cfg(feature = "tracing")]
-        let fut = fut.instrument(span);
+        let fut = async {
+            fut.await.or_else(|e| {
+                tracing::error!(error = %e);
+                Err(e)
+            })
+        }
+        .instrument(span);
 
         fut.boxed()
     }

--- a/src/tracing_utils.rs
+++ b/src/tracing_utils.rs
@@ -38,3 +38,16 @@ macro_rules! create_span {
         }
     }
 }
+
+#[cfg(feature = "tracing")]
+macro_rules! instrument_result {
+    ($fut:expr, $span:expr) => {{
+        let fut = async {
+            $fut.await.or_else(|e| {
+                tracing::error!(error = %e);
+                Err(e)
+            })
+        };
+        <_ as tracing::Instrument>::instrument(fut, $span)
+    }};
+}


### PR DESCRIPTION
Uses `tracing::error!(error = %err)` events like the `#[tracing::instrument(err)]` attribute.

Updates #223