### PR TITLE
Add feature flag for vendored OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ default-rustls = [
 ]
 minimal = ["flate2/zlib"]
 native-tls-tls = ["native-tls", "tokio-native-tls"]
+vendored-native-tls-tls = [
+    "native-tls-tls",
+    "tokio-native-tls/vendored",
+    "native-tls/vendored",
+]
 rustls-tls = [
     "rustls",
     "tokio-rustls",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ as well as `native-tls`-based TLS support.
     ```toml
     [dependencies]
     mysql_async = { version = "*", default-features = false, features = ["native-tls-tls"] }
+    ```
+
+*   `vendored-native-tls-tls` – enables `native-tls`-based TLS support, statically linking
+    a vendored copy of OpenSSL on Linux systems. This feature has the same effect as using
+    `native-tls-tls` on Windows and macOS, where OpenSSL is not used.
+    _(conflicts with `rustls-tls`)_
+
+    **Example:**
+
+    ```toml
+    [dependencies]
+    mysql_async = { version = "*", default-features = false, features = ["vendored-native-tls-tls"] }
+    ```
 
 *   `rustls-tls` – enables `native-tls`-based TLS support _(conflicts with `native-tls-tls`)_
 
@@ -79,6 +92,7 @@ as well as `native-tls`-based TLS support.
     ```toml
     [dependencies]
     mysql_async = { version = "*", default-features = false, features = ["rustls-tls"] }
+    ```
 
 *   `tracing` – enables instrumentation via `tracing` package.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,19 @@
 //!     ```toml
 //!     [dependencies]
 //!     mysql_async = { version = "*", default-features = false, features = ["native-tls-tls"] }
+//!     ```
+//!
+//! *   `vendored-native-tls-tls` – enables `native-tls`-based TLS support, statically linking
+//!     a vendored copy of OpenSSL on Linux systems. This feature has the same effect as using
+//!     `native-tls-tls` on Windows and macOS, where OpenSSL is not used.
+//!     _(conflicts with `rustls-tls`)_
+//!
+//!     **Example:**
+//!
+//!     ```toml
+//!     [dependencies]
+//!     mysql_async = { version = "*", default-features = false, features = ["vendored-native-tls-tls"] }
+//!     ```
 //!
 //! *   `rustls-tls` – enables `native-tls`-based TLS support _(conflicts with `native-tls-tls`)_
 //!
@@ -78,6 +91,7 @@
 //!     ```toml
 //!     [dependencies]
 //!     mysql_async = { version = "*", default-features = false, features = ["rustls-tls"] }
+//!     ```
 //!
 //! *   `tracing` – enables instrumentation via `tracing` package.
 //!


### PR DESCRIPTION
The `native-tls` and `tokio-native-tls` crates have a feature `vendored`, linking a vendored OpenSSL statically to the binary on Linux systems. We'd like to have a way to enable this feature from mysql_async for certain builds of ours.

This PR adds a new feature flag `vendored-native-tls-tls`, that enables vendoring and the use of `native-tls-tls` feature.