### PR TITLE
chore: replace webpki with rustls-webpki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
 lazy_static = "1"
-lru = "0.10.0"
+lru = "0.11.0"
 mio = { version = "0.8.0", features = ["os-poll", "net"] }
 mysql_common = { version = "0.30", default-features = false }
 once_cell = "1.7.2"
-pem = "2.0.1"
+pem = "3.0.1"
 percent-encoding = "2.1.0"
 pin-project = "1.0.2"
 serde = "1"
@@ -61,13 +61,12 @@ optional = true
 version = "1.0.1"
 optional = true
 
-[dependencies.webpki]
-version = "0.22.0"
-features = ["std"]
+[dependencies.rustls-webpki]
+version = "0.101.4"
 optional = true
 
 [dependencies.webpki-roots]
-version = "0.23.0"
+version = "0.25.0"
 optional = true
 
 [dev-dependencies]
@@ -100,9 +99,9 @@ native-tls-tls = ["native-tls", "tokio-native-tls"]
 rustls-tls = [
     "rustls",
     "tokio-rustls",
-    "webpki",
     "webpki-roots",
     "rustls-pemfile",
+    "rustls-webpki"
 ]
 tracing = ["dep:tracing"]
 derive = ["mysql_common/derive"]

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -23,7 +23,7 @@ impl Endpoint {
         }
 
         let mut root_store = RootCertStore::empty();
-        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
             OwnedTrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,
@@ -56,7 +56,7 @@ impl Endpoint {
 
         let mut config = if let Some(identity) = ssl_opts.client_identity() {
             let (cert_chain, priv_key) = identity.load()?;
-            config_builder.with_single_cert(cert_chain, priv_key)?
+            config_builder.with_client_auth_cert(cert_chain, priv_key)?
         } else {
             config_builder.with_no_client_auth()
         };


### PR DESCRIPTION


```
Crate:     webpki
Version:   0.22.0
Title:     webpki: CPU denial of service in certificate path building
Date:      2023-08-22
ID:        RUSTSEC-2023-0052
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0052
Severity:  7.5 (high)
Solution:  No fixed upgrade is available!
```