### PR TITLE
Option to set an absolute TTL for connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1.7.2"
 pem = "3.0"
 percent-encoding = "2.1.0"
 pin-project = "1.0.2"
+rand = "0.8.5"
 serde = "1"
 serde_json = "1"
 socket2 = "0.5.2"
@@ -74,7 +75,6 @@ optional = true
 tempfile = "3.1.0"
 socket2 = { version = "0.5.2", features = ["all"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
-rand = "0.8.0"
 
 [features]
 default = [


### PR DESCRIPTION
* The TTL, if set, forces connections to be disconnected, even overriding the minimum pool size constraint.
* The TTL can be combined with a random jitter value to prevent all connections closing at the same time.
* This enables gradual connection migration and regular connection recycling when automatic CONN_RESET is not desired.