### PR TITLE
Use an explicit priority check

### DIFF
--- a/src/conn/pool/futures/get_conn.rs
+++ b/src/conn/pool/futures/get_conn.rs
@@ -112,10 +112,8 @@ impl Future for GetConn {
         loop {
             match self.inner {
                 GetConnInner::New => {
-                    let queued = self.queue_id.is_some();
                     let queue_id = *self.queue_id.get_or_insert_with(QueueId::next);
-                    let next =
-                        ready!(Pin::new(self.pool_mut()).poll_new_conn(cx, queued, queue_id))?;
+                    let next = ready!(Pin::new(self.pool_mut()).poll_new_conn(cx, queue_id))?;
                     match next {
                         GetConnInner::Connecting(conn_fut) => {
                             self.inner = GetConnInner::Connecting(conn_fut);


### PR DESCRIPTION
This fixes the case where wake is called for one future, but another
future gets the connection