### PR TITLE
Silence clippy warnings

### DIFF
--- a/src/conn/binlog_stream/mod.rs
+++ b/src/conn/binlog_stream/mod.rs
@@ -166,6 +166,7 @@ impl futures_core::stream::Stream for BinlogStream {
                 Ok(Some(event)) => {
                     if event.header().event_type_raw() == EventType::TRANSACTION_PAYLOAD_EVENT as u8
                     {
+                        #[allow(clippy::single_match)]
                         match event.read_event::<TransactionPayloadEvent<'_>>() {
                             Ok(e) => self.tpe = Some(Cursor::new(e.danger_decompress())),
                             Err(_) => (/* TODO: Log the error */),

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -1048,6 +1048,7 @@ mod test {
         // queued.
         let conn = pool.get_conn().await.unwrap();
 
+        #[allow(clippy::async_yields_async)]
         let get_pending = || async {
             let fut = async {
                 pool.get_conn().await.unwrap();


### PR DESCRIPTION
In these cases I think the code is better as is, so I just silenced clippy.