### PR TITLE
Allow specifying root certs and Client Identity [for native-tls] as bytes rather than via a file

### DIFF
--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -142,6 +142,7 @@ pub struct SslOpts {
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     client_identity: Option<ClientIdentity>,
     root_cert_path: Option<Cow<'static, Path>>,
+    root_cert: Option<Vec<u8>>,
     skip_domain_validation: bool,
     accept_invalid_certs: bool,
 }
@@ -156,11 +157,24 @@ impl SslOpts {
     /// Sets path to a `pem` or `der` certificate of the root that connector will trust.
     ///
     /// Multiple certs are allowed in .pem files.
+    ///
+    /// Will be merged with any certs provided by `with_root_cert`.
     pub fn with_root_cert_path<T: Into<Cow<'static, Path>>>(
         mut self,
         root_cert_path: Option<T>,
     ) -> Self {
         self.root_cert_path = root_cert_path.map(Into::into);
+        self
+    }
+
+    /// Sets the bytes for a `pem` or `der` encoded certificate of the root that the connector
+    /// will trust.
+    ///
+    /// Multiple certs are allowed in .pem format.
+    ///
+    /// Will be merged with any certs provided by `with_root_cert_path`.
+    pub fn with_root_cert(mut self, cert: Option<Vec<u8>>) -> Self {
+        self.root_cert = cert;
         self
     }
 
@@ -185,6 +199,10 @@ impl SslOpts {
 
     pub fn root_cert_path(&self) -> Option<&Path> {
         self.root_cert_path.as_ref().map(AsRef::as_ref)
+    }
+
+    pub fn root_cert(&self) -> Option<&[u8]> {
+        self.root_cert.as_ref().map(AsRef::as_ref)
     }
 
     pub fn skip_domain_validation(&self) -> bool {

--- a/src/opts/native_tls_opts.rs
+++ b/src/opts/native_tls_opts.rs
@@ -3,8 +3,14 @@
 use std::{borrow::Cow, path::Path};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum Pkcs12Archive {
+    Path(Cow<'static, Path>),
+    Data(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClientIdentity {
-    pkcs12_path: Cow<'static, Path>,
+    pkcs12_archive: Pkcs12Archive,
     password: Option<Cow<'static, str>>,
 }
 
@@ -15,7 +21,15 @@ impl ClientIdentity {
         T: Into<Cow<'static, Path>>,
     {
         Self {
-            pkcs12_path: pkcs12_path.into(),
+            pkcs12_archive: Pkcs12Archive::Path(pkcs12_path.into()),
+            password: None,
+        }
+    }
+
+    /// Creates new identity with the given bytes for a pkcs12 archive.
+    pub fn new_from_bytes(pkcs12_data: Vec<u8>) -> Self {
+        Self {
+            pkcs12_archive: Pkcs12Archive::Data(pkcs12_data),
             password: None,
         }
     }
@@ -31,7 +45,18 @@ impl ClientIdentity {
 
     /// Returns the pkcs12 archive path.
     pub fn pkcs12_path(&self) -> &Path {
-        self.pkcs12_path.as_ref()
+        match &self.pkcs12_archive {
+            Pkcs12Archive::Path(path) => path.as_ref(),
+            Pkcs12Archive::Data(_) => panic!("pkcs12 archive path is not set"),
+        }
+    }
+
+    /// Returns the pkcs12 archive data, if set.
+    pub fn pkcs12_data(&self) -> Option<&[u8]> {
+        match &self.pkcs12_archive {
+            Pkcs12Archive::Data(data) => Some(data.as_ref()),
+            Pkcs12Archive::Path(_) => None,
+        }
     }
 
     /// Returns the archive password.


### PR DESCRIPTION
👋🏽  In our use-case we'd prefer not to have to generate files for providing root certs and client keys to `mysql_async` -- we already have those values as bytes and for security reasons don't want to expose them to the filesystem.

This PR adds a `with_root_cert` option to `SslOpts` to allow providing root CA certs directly, which are merged with any other certs specified by `with_root_cert_path`.
This also adds a `ClientIdentity::new_from_bytes` method to allow instantiating a native-tls `ClientIdentity` using the pkcs12 archive directly.
In both cases I avoided changing any existing APIs, but feel free to suggest an alternative design or implementation. Thanks!