### PR TITLE
annotate `Transaction` with `must_use`

### DIFF
--- a/src/queryable/transaction.rs
+++ b/src/queryable/transaction.rs
@@ -126,6 +126,7 @@ impl fmt::Display for IsolationLevel {
 ///
 /// You should always call either `commit` or `rollback`, otherwise transaction will be rolled
 /// back implicitly when corresponding connection is dropped or queried.
+#[must_use = "transaction object must be committed or rolled back explicitly"]
 #[derive(Debug)]
 pub struct Transaction<'a>(pub(crate) Connection<'a, 'static>);
 


### PR DESCRIPTION
It turns out it's easy to get confused and thing that you're running queries inside a transaction when in fact the transaction object gets dropped and will be implicitly rolled back when the connection terminates. Over at Materialize we just spend multiple days trying to understand why our consistency assumption weren't holding and it turned out we were dropping the transaction object on the floor.

This PR adds a `must_use` annotation as an aid to developers that they need to do something with the return value of `start_transaction`.