### PR TITLE
Allow specifying root certs and Client Identity as bytes rather than via a file

### DIFF
--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -7,12 +7,31 @@ use rustls::{
     Certificate, ClientConfig, OwnedTrustAnchor, RootCertStore,
 };
 
-use tokio::{fs::File, io::AsyncReadExt};
-
 use rustls_pemfile::certs;
 use tokio_rustls::TlsConnector;
 
 use crate::{io::Endpoint, Result, SslOpts};
+
+impl SslOpts {
+    async fn load_root_certs(&self) -> crate::Result<Vec<Certificate>> {
+        let mut output = Vec::new();
+
+        for root_cert in self.root_certs() {
+            let root_cert_data = root_cert.read().await?;
+            let mut seen = false;
+            for cert in certs(&mut &*root_cert_data)? {
+                seen = true;
+                output.push(Certificate(cert));
+            }
+
+            if !seen && !root_cert_data.is_empty() {
+                output.push(Certificate(root_cert_data.into_owned()));
+            }
+        }
+
+        Ok(output)
+    }
+}
 
 impl Endpoint {
     pub async fn make_secure(&mut self, domain: String, ssl_opts: SslOpts) -> Result<()> {
@@ -31,38 +50,8 @@ impl Endpoint {
             )
         }));
 
-        if let Some(root_cert_path) = ssl_opts.root_cert_path() {
-            let mut root_cert_data = vec![];
-            let mut root_cert_file = File::open(root_cert_path).await?;
-            root_cert_file.read_to_end(&mut root_cert_data).await?;
-
-            let mut root_certs = Vec::new();
-            for cert in certs(&mut &*root_cert_data)? {
-                root_certs.push(Certificate(cert));
-            }
-
-            if root_certs.is_empty() && !root_cert_data.is_empty() {
-                root_certs.push(Certificate(root_cert_data));
-            }
-
-            for cert in &root_certs {
-                root_store.add(cert)?;
-            }
-        }
-
-        if let Some(root_cert_data) = ssl_opts.root_cert() {
-            let mut root_certs = Vec::new();
-            for cert in certs(&mut &*root_cert_data)? {
-                root_certs.push(Certificate(cert));
-            }
-
-            if root_certs.is_empty() && !root_cert_data.is_empty() {
-                root_certs.push(Certificate(root_cert_data.to_vec()));
-            }
-
-            for cert in &root_certs {
-                root_store.add(cert)?;
-            }
+        for cert in ssl_opts.load_root_certs().await? {
+            root_store.add(&cert)?;
         }
 
         let config_builder = ClientConfig::builder()
@@ -70,7 +59,7 @@ impl Endpoint {
             .with_root_certificates(root_store.clone());
 
         let mut config = if let Some(identity) = ssl_opts.client_identity() {
-            let (cert_chain, priv_key) = identity.load()?;
+            let (cert_chain, priv_key) = identity.load().await?;
             config_builder.with_client_auth_cert(cert_chain, priv_key)?
         } else {
             config_builder.with_no_client_auth()

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -22,9 +22,9 @@ use url::{Host, Url};
 use std::{
     borrow::Cow,
     convert::TryFrom,
-    fmt,
+    fmt, io,
     net::{Ipv4Addr, Ipv6Addr},
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
@@ -115,6 +115,57 @@ impl HostPortOrUrl {
     }
 }
 
+/// Represents data that is either on-disk or in the buffer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+pub enum PathOrBuf<'a> {
+    Path(Cow<'a, Path>),
+    Buf(Cow<'a, [u8]>),
+}
+
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+impl<'a> PathOrBuf<'a> {
+    /// Will either read data from disk or return the buffered data.
+    pub async fn read(&self) -> io::Result<Cow<[u8]>> {
+        match self {
+            PathOrBuf::Path(x) => tokio::fs::read(x.as_ref()).await.map(Cow::Owned),
+            PathOrBuf::Buf(x) => Ok(Cow::Borrowed(x.as_ref())),
+        }
+    }
+
+    /// Borrows `self`.
+    pub fn borrow(&self) -> PathOrBuf<'_> {
+        match self {
+            PathOrBuf::Path(path) => PathOrBuf::Path(Cow::Borrowed(path.as_ref())),
+            PathOrBuf::Buf(data) => PathOrBuf::Buf(Cow::Borrowed(data.as_ref())),
+        }
+    }
+}
+
+impl From<PathBuf> for PathOrBuf<'static> {
+    fn from(value: PathBuf) -> Self {
+        Self::Path(Cow::Owned(value))
+    }
+}
+
+impl<'a> From<&'a Path> for PathOrBuf<'a> {
+    fn from(value: &'a Path) -> Self {
+        Self::Path(Cow::Borrowed(value))
+    }
+}
+
+impl From<Vec<u8>> for PathOrBuf<'static> {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Buf(Cow::Owned(value))
+    }
+}
+
+impl<'a> From<&'a [u8]> for PathOrBuf<'a> {
+    fn from(value: &'a [u8]) -> Self {
+        Self::Buf(Cow::Borrowed(value))
+    }
+}
+
 /// Ssl Options.
 ///
 /// ```
@@ -125,7 +176,7 @@ impl HostPortOrUrl {
 /// // With native-tls
 /// # #[cfg(feature = "native-tls-tls")]
 /// let ssl_opts = SslOpts::default()
-///     .with_client_identity(Some(ClientIdentity::new(Path::new("/path"))
+///     .with_client_identity(Some(ClientIdentity::new(Path::new("/path").into())
 ///         .with_password("******")
 ///     ));
 ///
@@ -133,16 +184,15 @@ impl HostPortOrUrl {
 /// # #[cfg(feature = "rustls-tls")]
 /// let ssl_opts = SslOpts::default()
 ///     .with_client_identity(Some(ClientIdentity::new(
-///         Path::new("/path/to/chain"),
-///         Path::new("/path/to/priv_key")
+///         Path::new("/path/to/chain").into(),
+///         Path::new("/path/to/priv_key").into(),
 /// )));
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct SslOpts {
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     client_identity: Option<ClientIdentity>,
-    root_cert_path: Option<Cow<'static, Path>>,
-    root_cert: Option<Vec<u8>>,
+    root_certs: Vec<PathOrBuf<'static>>,
     skip_domain_validation: bool,
     accept_invalid_certs: bool,
 }
@@ -158,23 +208,9 @@ impl SslOpts {
     ///
     /// Multiple certs are allowed in .pem files.
     ///
-    /// Will be merged with any certs provided by `with_root_cert`.
-    pub fn with_root_cert_path<T: Into<Cow<'static, Path>>>(
-        mut self,
-        root_cert_path: Option<T>,
-    ) -> Self {
-        self.root_cert_path = root_cert_path.map(Into::into);
-        self
-    }
-
-    /// Sets the bytes for a `pem` or `der` encoded certificate of the root that the connector
-    /// will trust.
-    ///
-    /// Multiple certs are allowed in .pem format.
-    ///
-    /// Will be merged with any certs provided by `with_root_cert_path`.
-    pub fn with_root_cert(mut self, cert: Option<Vec<u8>>) -> Self {
-        self.root_cert = cert;
+    /// All the elements in `root_certs` will be merged.
+    pub fn with_root_certs(mut self, root_certs: Vec<PathOrBuf<'static>>) -> Self {
+        self.root_certs = root_certs;
         self
     }
 
@@ -197,12 +233,8 @@ impl SslOpts {
         self.client_identity.as_ref()
     }
 
-    pub fn root_cert_path(&self) -> Option<&Path> {
-        self.root_cert_path.as_ref().map(AsRef::as_ref)
-    }
-
-    pub fn root_cert(&self) -> Option<&[u8]> {
-        self.root_cert.as_ref().map(AsRef::as_ref)
+    pub fn root_certs(&self) -> &[PathOrBuf<'static>] {
+        &self.root_certs
     }
 
     pub fn skip_domain_validation(&self) -> bool {

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -142,6 +142,7 @@ pub struct SslOpts {
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     client_identity: Option<ClientIdentity>,
     root_cert_path: Option<Cow<'static, Path>>,
+    root_cert: Option<Vec<u8>>,
     skip_domain_validation: bool,
     accept_invalid_certs: bool,
 }
@@ -156,11 +157,24 @@ impl SslOpts {
     /// Sets path to a `pem` or `der` certificate of the root that connector will trust.
     ///
     /// Multiple certs are allowed in .pem files.
+    ///
+    /// Will be merged with any certs provided by `with_root_cert`.
     pub fn with_root_cert_path<T: Into<Cow<'static, Path>>>(
         mut self,
         root_cert_path: Option<T>,
     ) -> Self {
         self.root_cert_path = root_cert_path.map(Into::into);
+        self
+    }
+
+    /// Sets the bytes for a `pem` or `der` encoded certificate of the root that the connector
+    /// will trust.
+    ///
+    /// Multiple certs are allowed in .pem format.
+    ///
+    /// Will be merged with any certs provided by `with_root_cert_path`.
+    pub fn with_root_cert(mut self, cert: Option<Vec<u8>>) -> Self {
+        self.root_cert = cert;
         self
     }
 
@@ -185,6 +199,10 @@ impl SslOpts {
 
     pub fn root_cert_path(&self) -> Option<&Path> {
         self.root_cert_path.as_ref().map(AsRef::as_ref)
+    }
+
+    pub fn root_cert(&self) -> Option<&[u8]> {
+        self.root_cert.as_ref().map(AsRef::as_ref)
     }
 
     pub fn skip_domain_validation(&self) -> bool {

--- a/src/opts/native_tls_opts.rs
+++ b/src/opts/native_tls_opts.rs
@@ -3,8 +3,14 @@
 use std::{borrow::Cow, path::Path};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum Pkcs12Archive {
+    Path(Cow<'static, Path>),
+    Data(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClientIdentity {
-    pkcs12_path: Cow<'static, Path>,
+    pkcs12_archive: Pkcs12Archive,
     password: Option<Cow<'static, str>>,
 }
 
@@ -15,7 +21,15 @@ impl ClientIdentity {
         T: Into<Cow<'static, Path>>,
     {
         Self {
-            pkcs12_path: pkcs12_path.into(),
+            pkcs12_archive: Pkcs12Archive::Path(pkcs12_path.into()),
+            password: None,
+        }
+    }
+
+    /// Creates new identity with the given bytes for a pkcs12 archive.
+    pub fn new_from_bytes(pkcs12_data: Vec<u8>) -> Self {
+        Self {
+            pkcs12_archive: Pkcs12Archive::Data(pkcs12_data),
             password: None,
         }
     }
@@ -31,7 +45,18 @@ impl ClientIdentity {
 
     /// Returns the pkcs12 archive path.
     pub fn pkcs12_path(&self) -> &Path {
-        self.pkcs12_path.as_ref()
+        match &self.pkcs12_archive {
+            Pkcs12Archive::Path(path) => path.as_ref(),
+            Pkcs12Archive::Data(_) => panic!("pkcs12 archive path is not set"),
+        }
+    }
+
+    /// Returns the pkcs12 archive data, if set.
+    pub fn pkcs12_data(&self) -> Option<&[u8]> {
+        match &self.pkcs12_archive {
+            Pkcs12Archive::Data(data) => Some(data.as_ref()),
+            Pkcs12Archive::Path(_) => None,
+        }
     }
 
     /// Returns the archive password.

--- a/src/opts/native_tls_opts.rs
+++ b/src/opts/native_tls_opts.rs
@@ -1,37 +1,30 @@
 #![cfg(feature = "native-tls")]
 
-use std::{borrow::Cow, path::Path};
+use std::borrow::Cow;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum Pkcs12Archive {
-    Path(Cow<'static, Path>),
-    Data(Vec<u8>),
-}
+use native_tls::Identity;
+
+use super::PathOrBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClientIdentity {
-    pkcs12_archive: Pkcs12Archive,
+    pkcs12_archive: PathOrBuf<'static>,
     password: Option<Cow<'static, str>>,
 }
 
 impl ClientIdentity {
-    /// Creates new identity with the given path to the pkcs12 archive.
-    pub fn new<T>(pkcs12_path: T) -> Self
-    where
-        T: Into<Cow<'static, Path>>,
-    {
+    /// Creates new identity with the given pkcs12 archive.
+    pub fn new(pkcs12_archive: PathOrBuf<'static>) -> Self {
         Self {
-            pkcs12_archive: Pkcs12Archive::Path(pkcs12_path.into()),
+            pkcs12_archive,
             password: None,
         }
     }
 
-    /// Creates new identity with the given bytes for a pkcs12 archive.
-    pub fn new_from_bytes(pkcs12_data: Vec<u8>) -> Self {
-        Self {
-            pkcs12_archive: Pkcs12Archive::Data(pkcs12_data),
-            password: None,
-        }
+    /// Sets the pkcs12 archive.
+    pub fn with_pkcs12_archive(mut self, pkcs12_archive: PathOrBuf<'static>) -> Self {
+        self.pkcs12_archive = pkcs12_archive;
+        self
     }
 
     /// Sets the archive password.
@@ -43,24 +36,19 @@ impl ClientIdentity {
         self
     }
 
-    /// Returns the pkcs12 archive path.
-    pub fn pkcs12_path(&self) -> &Path {
-        match &self.pkcs12_archive {
-            Pkcs12Archive::Path(path) => path.as_ref(),
-            Pkcs12Archive::Data(_) => panic!("pkcs12 archive path is not set"),
-        }
-    }
-
-    /// Returns the pkcs12 archive data, if set.
-    pub fn pkcs12_data(&self) -> Option<&[u8]> {
-        match &self.pkcs12_archive {
-            Pkcs12Archive::Data(data) => Some(data.as_ref()),
-            Pkcs12Archive::Path(_) => None,
-        }
+    /// Returns the pkcs12 archive.
+    pub fn pkcs12_archive(&self) -> PathOrBuf<'_> {
+        self.pkcs12_archive.borrow()
     }
 
     /// Returns the archive password.
     pub fn password(&self) -> Option<&str> {
         self.password.as_ref().map(AsRef::as_ref)
+    }
+
+    pub(crate) async fn load(&self) -> crate::Result<Identity> {
+        let der = self.pkcs12_archive.read().await?;
+        let password = self.password().unwrap_or_default();
+        Ok(Identity::from_pkcs12(der.as_ref(), password)?)
     }
 }

--- a/src/opts/rustls_opts.rs
+++ b/src/opts/rustls_opts.rs
@@ -5,79 +5,73 @@ use rustls_pemfile::{certs, rsa_private_keys};
 
 use std::{borrow::Cow, path::Path};
 
+use super::PathOrBuf;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClientIdentity {
-    cert_chain_path: Cow<'static, Path>,
-    priv_key_path: Cow<'static, Path>,
+    cert_chain: PathOrBuf<'static>,
+    priv_key: PathOrBuf<'static>,
 }
 
 impl ClientIdentity {
     /// Creates new identity.
     ///
-    /// `cert_chain_path` - path to a certificate chain (in PEM or DER)
-    /// `priv_key_path` - path to a private key (in DER or PEM) (it'll take the first one)
-    pub fn new<T, U>(cert_chain_path: T, priv_key_path: U) -> Self
-    where
-        T: Into<Cow<'static, Path>>,
-        U: Into<Cow<'static, Path>>,
-    {
+    /// `cert_chain` - certificate chain (in PEM or DER)
+    /// `priv_key` - private key (in DER or PEM) (it'll take the first one)
+    pub fn new(cert_chain: PathOrBuf<'static>, priv_key: PathOrBuf<'static>) -> Self {
         Self {
-            cert_chain_path: cert_chain_path.into(),
-            priv_key_path: priv_key_path.into(),
+            cert_chain,
+            priv_key,
         }
     }
 
     /// Sets the certificate chain path (in DER or PEM).
-    pub fn with_cert_chain_path<T>(mut self, cert_chain_path: T) -> Self
-    where
-        T: Into<Cow<'static, Path>>,
-    {
-        self.cert_chain_path = cert_chain_path.into();
+    pub fn with_cert_chain(mut self, cert_chain: PathOrBuf<'static>) -> Self {
+        self.cert_chain = cert_chain;
         self
     }
 
     /// Sets the private key path (in DER or PEM) (it'll take the first one).
-    pub fn with_priv_key_path<T>(mut self, priv_key_path: T) -> Self
+    pub fn with_priv_key<T>(mut self, priv_key: PathOrBuf<'static>) -> Self
     where
         T: Into<Cow<'static, Path>>,
     {
-        self.priv_key_path = priv_key_path.into();
+        self.priv_key = priv_key;
         self
     }
 
-    /// Returns the certificate chain path.
-    pub fn cert_chain_path(&self) -> &Path {
-        self.cert_chain_path.as_ref()
+    /// Returns the certificate chain.
+    pub fn cert_chain(&self) -> PathOrBuf<'_> {
+        self.cert_chain.borrow()
     }
 
-    /// Returns the private key path.
-    pub fn priv_key_path(&self) -> &Path {
-        self.priv_key_path.as_ref()
+    /// Returns the private key.
+    pub fn priv_key(&self) -> PathOrBuf<'_> {
+        self.priv_key.borrow()
     }
 
-    pub(crate) fn load(&self) -> crate::Result<(Vec<Certificate>, PrivateKey)> {
-        let cert_data = std::fs::read(self.cert_chain_path.as_ref())?;
-        let key_data = std::fs::read(self.priv_key_path.as_ref())?;
+    pub(crate) async fn load(&self) -> crate::Result<(Vec<Certificate>, PrivateKey)> {
+        let cert_data = self.cert_chain.read().await?;
+        let key_data = self.priv_key.read().await?;
 
         let mut cert_chain = Vec::new();
         if std::str::from_utf8(&cert_data).is_err() {
-            cert_chain.push(Certificate(cert_data));
+            cert_chain.push(Certificate(cert_data.into_owned()));
         } else {
             for cert in certs(&mut &*cert_data)? {
                 cert_chain.push(Certificate(cert));
             }
         }
 
-        let priv_key;
-        if std::str::from_utf8(&key_data).is_err() {
-            priv_key = Some(PrivateKey(key_data));
+        let priv_key = if std::str::from_utf8(&key_data).is_err() {
+            Some(PrivateKey(key_data.into_owned()))
         } else {
-            priv_key = rsa_private_keys(&mut &*key_data)?
+            rsa_private_keys(&mut &*key_data)?
                 .into_iter()
                 .take(1)
                 .map(PrivateKey)
-                .next();
-        }
+                .next()
+        };
 
         Ok((
             cert_chain,


### PR DESCRIPTION
This supersedes #288 because I don't have write access to the fork.
The purpose is to add this feature to the rustls backend.