### PR TITLE
ci: update MariaDB versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,30 +132,28 @@ jobs:
           DATABASE_URL: mysql://root:password@127.0.0.1/mysql
         displayName: Run tests in Docker
 
-  - job: "TestMariaDb"
+  - job: "TestMariaDB"
     pool:
       vmImage: "ubuntu-latest"
     strategy:
       maxParallel: 10
       matrix:
-        v107:
-          DB_VERSION: "10.7"
+        verylatest:
+          CONTAINER: "quay.io/mariadb-foundation/mariadb-devel:verylatest"
+        latest:
+          CONTAINER: "quay.io/mariadb-foundation/mariadb-devel:latest"
+        v1011:
+          CONTAINER: "mariadb:10.11"
         v106:
-          DB_VERSION: "10.6"
+          CONTAINER: "mariadb:10.6"
         v105:
-          DB_VERSION: "10.5"
+          CONTAINER: "mariadb:10.5"
         v104:
-          DB_VERSION: "10.4"
-        v103:
-          DB_VERSION: "10.3"
-        v102:
-          DB_VERSION: "10.2"
-        v101:
-          DB_VERSION: "10.1"
+          CONTAINER: "mariadb:10.4"
     steps:
       - bash: |
           sudo apt-get update
-          sudo apt-get install docker.io netcat grep
+          sudo apt-get install docker.io
           sudo systemctl unmask docker
           sudo systemctl start docker
           docker --version
@@ -171,8 +169,7 @@ jobs:
               -v `pwd`:/root \
               -p 3307:3306 \
               -e MARIADB_ROOT_PASSWORD=password \
-              -e MYSQL_ROOT_PASSWORD=password \
-              mariadb:$(DB_VERSION) \
+              $(CONTAINER) \
                   --max-allowed-packet=36700160 \
                   --local-infile \
                   --performance-schema=on \
@@ -181,8 +178,8 @@ jobs:
                   --ssl-ca=/root/rust-mysql-simple/tests/ca.crt \
                   --ssl-cert=/root/rust-mysql-simple/tests/server.crt \
                   --ssl-key=/root/rust-mysql-simple/tests/server-key.pem &
-          while ! nc -W 1 localhost 3307 | grep -q -P '.+'; do sleep 1; done
-        displayName: Run MariaDb in Docker
+          while ! docker exec container healthcheck.sh --connect --innodb_initialized ; do sleep 1; echo waiting; done
+        displayName: Run MariaDB in Docker
       - bash: |
           docker exec container bash -l -c "apt-get update"
           docker exec container bash -l -c "apt-get install -y curl clang libssl-dev pkg-config"
@@ -193,7 +190,7 @@ jobs:
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL COMPRESS=true cargo test"
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test"
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test"
-          if [[ "10.1" != "$(DB_VERSION)" ]]; then docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --no-default-features --features default-rustls"; fi
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --no-default-features --features default-rustls"
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:password@127.0.0.1/mysql


### PR DESCRIPTION
MariaDB versions where a little out of date. 10.7 and <=10.3 are end of maintained versions.

Currently supported versions are: https://mariadb.org/about/#maintenance-policy

Add latest and very latest development versions so incompatibilities can be found pre-release
(ref:
https://mariadb.org/new-service-quay-io-mariadb-foundation-mariadb-devel/).

A healthcheck.sh script is there for convience.
(https://mariadb.com/kb/en/using-healthcheck-sh-script/).

Only MARIADB_ROOT_PASSWORD is required as env variable.