### PR TITLE
Compatibility with non-Unix and non-Windows platforms.

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -913,7 +913,7 @@ impl Conn {
                 {
                     Stream::connect_socket(_path.to_owned()).await?
                 }
-                #[cfg(target_os = "windows")]
+                #[cfg(not(unix))]
                 return Err(crate::DriverError::NamedPipesDisabled.into());
             } else {
                 let keepalive = opts

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,6 +12,7 @@ use bytes::BytesMut;
 use futures_core::{ready, stream};
 use mysql_common::proto::codec::PacketCodec as PacketCodecInner;
 use pin_project::pin_project;
+#[cfg(any(unix, windows))]
 use socket2::{Socket as Socket2Socket, TcpKeepalive};
 #[cfg(unix)]
 use tokio::io::AsyncWriteExt;
@@ -378,6 +379,7 @@ impl Stream {
             }
         };
 
+        #[cfg(any(unix, windows))]
         if let Some(duration) = keepalive {
             #[cfg(unix)]
             let socket = {


### PR DESCRIPTION
I found that when my compilation target is neither Unix nor Windows, the compilation fails with syntax errors.

Although some trivial features will be disabled as a result, it's still much better overall than not being able to use it at all.
