### PR TITLE
Update README.md with supported MariaDB and MySQL versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # mysql_async
 
-Tokio based asynchronous MySql client library for The Rust Programming Language.
+Tokio based asynchronous MySql client library for The Rust Programming Language. Supported by MariaDB 10.4, 10.5, 10.6, 10.11 and 11.4 as well as MySQL 5.6, 5.7 and 8.0.
 
 ## Installation
 


### PR DESCRIPTION
Adding supported MariaDB and MySQL versions to README based on versions mentioned in [azure-pipelines.yml](https://github.com/blackbeam/mysql_async/blob/master/azure-pipelines.yml).