### PR TITLE
Lower log level of events that are typically handled by application

### DIFF
--- a/src/tracing_utils.rs
+++ b/src/tracing_utils.rs
@@ -47,14 +47,17 @@ macro_rules! instrument_result {
                 match &e {
                     $crate::error::Error::Server(server_error) => {
                         match server_error.code {
+                            // Duplicated entry for key
                             1062 => {
-                                tracing::warn!(error = %e, "duplicated entry for key")
+                                tracing::warn!(error = %e)
                             }
+                            // Foreign key violation
                             1451 => {
-                                tracing::warn!(error = %e, "foreign key violation")
+                                tracing::warn!(error = %e)
                             }
+                            // User defined exception condition
                             1644 => {
-                                tracing::warn!(error = %e, "user defined exception condition");
+                                tracing::warn!(error = %e);
                             }
                             _ => tracing::error!(error = %e),
                         }


### PR DESCRIPTION
Dear @blackbeam,

I'm opening this PR to present an issue that I'm having with `mysql_async`.
Currently, this crate is emitting all `Err` variants as `error!` events.

Most of the time this is desirable, but sometimes this level is too severe.

When inserting duplicate values, deleting a value that is in use by another table, matching the `Err` variant is very convenient. A query that returns `Err` could be a benign error that is handled by the application, and a lower event level would be better. 

This PR matches the `ServerError` and looks at its error code to decide whether to emit an `error!` or a `warn!`.
