### PR TITLE
Add SslOpts::disable_built_in_roots flag

### DIFF
--- a/src/io/tls/native_tls_io.rs
+++ b/src/io/tls/native_tls_io.rs
@@ -36,6 +36,7 @@ impl Endpoint {
         }
         builder.danger_accept_invalid_hostnames(ssl_opts.skip_domain_validation());
         builder.danger_accept_invalid_certs(ssl_opts.accept_invalid_certs());
+        builder.disable_built_in_roots(ssl_opts.disable_built_in_roots());
         let tls_connector: tokio_native_tls::TlsConnector = builder.build()?.into();
 
         *self = match self {

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -46,7 +46,9 @@ impl Endpoint {
         }
 
         let mut root_store = RootCertStore::empty();
-        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|x| x.to_owned()));
+        if !ssl_opts.disable_built_in_roots() {
+            root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|x| x.to_owned()));
+        }
 
         for cert in ssl_opts.load_root_certs().await? {
             root_store.add(cert)?;

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -262,7 +262,7 @@ impl SslOpts {
     ///
     /// # Connection URL
     ///
-    /// Use `built_in_roots` URL parameter to set this value:
+    /// Use `verify_identity` URL parameter to set this value:
     ///
     /// ```
     /// # use mysql_async::*;

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -214,6 +214,7 @@ pub struct SslOpts {
     #[cfg(any(feature = "native-tls-tls", feature = "rustls-tls"))]
     client_identity: Option<ClientIdentity>,
     root_certs: Vec<PathOrBuf<'static>>,
+    disable_built_in_roots: bool,
     skip_domain_validation: bool,
     accept_invalid_certs: bool,
     tls_hostname_override: Option<Cow<'static, str>>,
@@ -233,6 +234,13 @@ impl SslOpts {
     /// All the elements in `root_certs` will be merged.
     pub fn with_root_certs(mut self, root_certs: Vec<PathOrBuf<'static>>) -> Self {
         self.root_certs = root_certs;
+        self
+    }
+
+    /// If `true`, use only the root certificates configured via `with_root_certs`,
+    /// not any system or built-in certs.
+    pub fn with_disable_built_in_roots(mut self, disable_built_in_roots: bool) -> Self {
+        self.disable_built_in_roots = disable_built_in_roots;
         self
     }
 
@@ -269,6 +277,10 @@ impl SslOpts {
 
     pub fn root_certs(&self) -> &[PathOrBuf<'static>] {
         &self.root_certs
+    }
+
+    pub fn disable_built_in_roots(&self) -> bool {
+        self.disable_built_in_roots
     }
 
     pub fn skip_domain_validation(&self) -> bool {


### PR DESCRIPTION
This lets the user customize exactly what root certificates they want to accept.