### PR TITLE
add glue code for ed25519 auth method in mysql_common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
 lru = "0.12.0"
-mysql_common = { version = "0.34", default-features = false }
+mysql_common = { version = "0.35", default-features = false }
 pem = "3.0"
 percent-encoding = "2.1.0"
 pin-project = "1.0.2"
@@ -121,6 +121,7 @@ time = ["mysql_common/time"]
 bigdecimal = ["mysql_common/bigdecimal"]
 rust_decimal = ["mysql_common/rust_decimal"]
 frunk = ["mysql_common/frunk"]
+client_ed25519 = ["mysql_common/client_ed25519"]
 
 # other features
 tracing = ["dep:tracing"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,6 +183,7 @@ jobs:
           git checkout 901a7de
         displayName: Clone rust-mysql-simple (for ssl certs)
       - bash: |
+          if [[ "11.6.2" == "$(DB_VERSION)" ]]; then ARG=" --plugin-load-add=auth_ed25519"; fi
           docker run --rm -d \
               --name container \
               -v `pwd`:/root \
@@ -197,7 +198,9 @@ jobs:
                   --ssl \
                   --ssl-ca=/root/rust-mysql-simple/tests/ca.crt \
                   --ssl-cert=/root/rust-mysql-simple/tests/server.crt \
-                  --ssl-key=/root/rust-mysql-simple/tests/server-key.pem &
+                  --ssl-key=/root/rust-mysql-simple/tests/server-key.pem \
+                  --secure-auth=OFF \
+                  $ARG &
           while ! nc -W 1 localhost 3307 | grep -q -P '.+'; do sleep 1; done
         displayName: Run MariaDb in Docker
       - bash: |
@@ -206,11 +209,12 @@ jobs:
           docker exec container bash -l -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable"
         displayName: Install Rust in docker
       - bash: |
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL cargo test"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL COMPRESS=true cargo test"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --features native-tls-tls"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test"
-          if [[ "10.1" != "$(DB_VERSION)" ]]; then docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --no-default-features --features default-rustls"; fi
+          if [[ "11.6.2" == "$(DB_VERSION)" ]]; then FEATURES="client_ed25519"; fi
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL cargo test --features $FEATURES"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL COMPRESS=true cargo test --features $FEATURES"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --features native-tls-tls,$FEATURES"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --features $FEATURES"
+          if [[ "10.1" != "$(DB_VERSION)" ]]; then docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --no-default-features --features default-rustls,$FEATURES"; fi
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:password@127.0.0.1/mysql

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -703,6 +703,10 @@ impl Conn {
                 // ok packet for empty password
                 Ok(())
             },
+            Some(0xfe) if !self.inner.auth_switched => {
+                let auth_switch_request = ParseBuf(&packet).parse::<AuthSwitchRequest>(())?;
+                self.perform_auth_switch(auth_switch_request).await
+            },
             _ => Err(DriverError::UnexpectedPacket {
                 payload: packet.to_vec(),
             }.into()),


### PR DESCRIPTION
This PR adds the glue code necessary to make use of the ed25519 auth method added to mysql_common [here](https://github.com/blackbeam/rust_mysql_common/pull/144).