### PR TITLE
Cache the TlsConnector built from SslOpts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1"
 serde_json = "1"
 socket2 = "0.5.2"
 thiserror = "2"
-tokio = { version = "1.0", features = ["io-util", "fs", "net", "time", "rt"] }
+tokio = { version = "1.0", features = ["io-util", "fs", "net", "time", "rt", "sync"] }
 tokio-util = { version = "0.7.2", features = ["codec", "io"] }
 tracing = { version = "0.1.37", default-features = false, features = [
     "attributes",

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -549,12 +549,16 @@ impl Conn {
             );
             self.write_struct(&ssl_request).await?;
             let conn = self;
-            let ssl_opts = conn.opts().ssl_opts().cloned().expect("unreachable");
+            let ssl_opts = conn.opts().ssl_opts_and_connector().expect("unreachable");
             let domain = ssl_opts
+                .ssl_opts()
                 .tls_hostname_override()
                 .unwrap_or_else(|| conn.opts().ip_or_hostname())
                 .into();
-            conn.stream_mut()?.make_secure(domain, ssl_opts).await?;
+            let tls_connector = ssl_opts.build_tls_connector().await?;
+            conn.stream_mut()?
+                .make_secure(domain, &tls_connector)
+                .await?;
             Ok(())
         } else {
             Ok(())

--- a/src/io/tls/mod.rs
+++ b/src/io/tls/mod.rs
@@ -1,4 +1,13 @@
-#![cfg(any(feature = "native-tls-tls", feature = "rustls"))]
-
+#[cfg(feature = "native-tls-tls")]
 mod native_tls_io;
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls-tls")))]
+mod no_tls;
+#[cfg(feature = "rustls-tls")]
 mod rustls_io;
+
+#[cfg(feature = "native-tls-tls")]
+pub(crate) use self::native_tls_io::TlsConnector;
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls-tls")))]
+pub(crate) use self::no_tls::TlsConnector;
+#[cfg(feature = "rustls-tls")]
+pub(crate) use self::rustls_io::TlsConnector;

--- a/src/io/tls/native_tls_io.rs
+++ b/src/io/tls/native_tls_io.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "native-tls-tls")]
-
-use native_tls::{Certificate, TlsConnector};
+use tokio_native_tls::native_tls::{self, Certificate};
 
 use crate::io::Endpoint;
 use crate::{Result, SslOpts};
+
+pub use tokio_native_tls::TlsConnector;
 
 impl SslOpts {
     async fn load_root_certs(&self) -> crate::Result<Vec<Certificate>> {
@@ -16,28 +16,35 @@ impl SslOpts {
 
         Ok(output)
     }
+
+    pub(crate) async fn build_tls_connector(&self) -> Result<TlsConnector> {
+        let mut builder = native_tls::TlsConnector::builder();
+        for root_cert in self.load_root_certs().await? {
+            builder.add_root_certificate(root_cert);
+        }
+
+        if let Some(client_identity) = self.client_identity() {
+            builder.identity(client_identity.load().await?);
+        }
+        builder.danger_accept_invalid_hostnames(self.skip_domain_validation());
+        builder.danger_accept_invalid_certs(self.accept_invalid_certs());
+        builder.disable_built_in_roots(self.disable_built_in_roots());
+        let tls_connector: TlsConnector = builder.build()?.into();
+        Ok(tls_connector)
+    }
 }
 
 impl Endpoint {
-    pub async fn make_secure(&mut self, domain: String, ssl_opts: SslOpts) -> Result<()> {
+    pub async fn make_secure(
+        &mut self,
+        domain: String,
+        tls_connector: &TlsConnector,
+    ) -> Result<()> {
         #[cfg(unix)]
         if self.is_socket() {
             // won't secure socket connection
             return Ok(());
         }
-
-        let mut builder = TlsConnector::builder();
-        for root_cert in ssl_opts.load_root_certs().await? {
-            builder.add_root_certificate(root_cert);
-        }
-
-        if let Some(client_identity) = ssl_opts.client_identity() {
-            builder.identity(client_identity.load().await?);
-        }
-        builder.danger_accept_invalid_hostnames(ssl_opts.skip_domain_validation());
-        builder.danger_accept_invalid_certs(ssl_opts.accept_invalid_certs());
-        builder.disable_built_in_roots(ssl_opts.disable_built_in_roots());
-        let tls_connector: tokio_native_tls::TlsConnector = builder.build()?.into();
 
         *self = match self {
             Endpoint::Plain(ref mut stream) => {

--- a/src/io/tls/no_tls.rs
+++ b/src/io/tls/no_tls.rs
@@ -1,0 +1,24 @@
+use crate::io::Endpoint;
+use crate::{Result, SslOpts};
+
+#[derive(Clone, Debug)]
+pub(crate) struct TlsConnector;
+
+impl SslOpts {
+    pub(crate) async fn build_tls_connector(&self) -> Result<TlsConnector> {
+        panic!(
+            "Client had asked for TLS connection but TLS support is disabled. \
+            Please enable one of the following features: [\"native-tls-tls\", \"rustls-tls\"]"
+        )
+    }
+}
+
+impl Endpoint {
+    pub async fn make_secure(
+        &mut self,
+        _domain: String,
+        _tls_connector: &TlsConnector,
+    ) -> Result<()> {
+        unreachable!();
+    }
+}

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -17,6 +17,7 @@ pub use rustls_opts::ClientIdentity;
 
 use percent_encoding::percent_decode;
 use rand::Rng;
+use tokio::sync::OnceCell;
 use url::{Host, Url};
 
 use std::{
@@ -603,7 +604,7 @@ pub(crate) struct MysqlOpts {
     stmt_cache_size: usize,
 
     /// Driver will require SSL connection if this option isn't `None` (default to `None`).
-    ssl_opts: Option<SslOpts>,
+    ssl_opts: Option<SslOptsAndCachedConnector>,
 
     /// Prefer socket connection (defaults to `true`).
     ///
@@ -949,7 +950,7 @@ impl Opts {
     ///
     ///
     pub fn ssl_opts(&self) -> Option<&SslOpts> {
-        self.inner.mysql_opts.ssl_opts.as_ref()
+        self.inner.mysql_opts.ssl_opts.as_ref().map(|o| &o.ssl_opts)
     }
 
     /// Prefer socket connection (defaults to `true` **temporary `false` on Windows platform**).
@@ -1112,6 +1113,10 @@ impl Opts {
 
         out
     }
+
+    pub(crate) fn ssl_opts_and_connector(&self) -> Option<&SslOptsAndCachedConnector> {
+        self.inner.mysql_opts.ssl_opts.as_ref()
+    }
 }
 
 impl Default for MysqlOpts {
@@ -1140,6 +1145,47 @@ impl Default for MysqlOpts {
         }
     }
 }
+
+#[derive(Clone)]
+pub(crate) struct SslOptsAndCachedConnector {
+    ssl_opts: SslOpts,
+    tls_connector: Arc<OnceCell<crate::io::TlsConnector>>,
+}
+
+impl fmt::Debug for SslOptsAndCachedConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SslOptsAndCachedConnector")
+            .field("ssl_opts", &self.ssl_opts)
+            .finish()
+    }
+}
+
+impl SslOptsAndCachedConnector {
+    fn new(ssl_opts: SslOpts) -> Self {
+        Self {
+            ssl_opts,
+            tls_connector: Arc::new(OnceCell::new()),
+        }
+    }
+
+    pub(crate) fn ssl_opts(&self) -> &SslOpts {
+        &self.ssl_opts
+    }
+
+    pub(crate) async fn build_tls_connector(&self) -> Result<crate::io::TlsConnector> {
+        self.tls_connector
+            .get_or_try_init(move || self.ssl_opts.build_tls_connector())
+            .await
+            .cloned()
+    }
+}
+
+impl PartialEq for SslOptsAndCachedConnector {
+    fn eq(&self, other: &Self) -> bool {
+        self.ssl_opts == other.ssl_opts
+    }
+}
+impl Eq for SslOptsAndCachedConnector {}
 
 /// Connection pool constraints.
 ///
@@ -1349,7 +1395,7 @@ impl OptsBuilder {
 
     /// Defines SSL options. See [`Opts::ssl_opts`].
     pub fn ssl_opts<T: Into<Option<SslOpts>>>(mut self, ssl_opts: T) -> Self {
-        self.opts.ssl_opts = ssl_opts.into();
+        self.opts.ssl_opts = ssl_opts.into().map(SslOptsAndCachedConnector::new);
         self
     }
 
@@ -1632,6 +1678,7 @@ fn mysqlopts_from_url(url: &Url) -> std::result::Result<MysqlOpts, UrlError> {
     let mut pool_min = DEFAULT_POOL_CONSTRAINTS.min;
     let mut pool_max = DEFAULT_POOL_CONSTRAINTS.max;
 
+    let mut ssl_opts = None;
     let mut skip_domain_validation = false;
     let mut accept_invalid_certs = false;
     let mut disable_built_in_roots = false;
@@ -1855,7 +1902,9 @@ fn mysqlopts_from_url(url: &Url) -> std::result::Result<MysqlOpts, UrlError> {
             }
         } else if key == "require_ssl" {
             match bool::from_str(&value) {
-                Ok(x) => opts.ssl_opts = x.then(SslOpts::default),
+                Ok(x) => {
+                    ssl_opts = x.then(SslOpts::default);
+                }
                 _ => {
                     return Err(UrlError::InvalidParamValue {
                         param: "require_ssl".into(),
@@ -1913,11 +1962,13 @@ fn mysqlopts_from_url(url: &Url) -> std::result::Result<MysqlOpts, UrlError> {
         });
     }
 
-    if let Some(ref mut ssl_opts) = opts.ssl_opts.as_mut() {
+    if let Some(ref mut ssl_opts) = ssl_opts {
         ssl_opts.accept_invalid_certs = accept_invalid_certs;
         ssl_opts.skip_domain_validation = skip_domain_validation;
         ssl_opts.disable_built_in_roots = disable_built_in_roots;
     }
+
+    opts.ssl_opts = ssl_opts.map(SslOptsAndCachedConnector::new);
 
     Ok(opts)
 }


### PR DESCRIPTION
Constructing a TlsConnector is fairly expensive - it can involve searching for and parsing certificates, for example.
Both native-tls and rustls therefore allow a single TlsConnector to be used to connect many times.

To avoid adding a fallible (and async) initialization step and therefore preserve the public API of this crate, this PR caches the TlsConnector beside the SslOpts using a tokio OnceCell, so that any error from its construction still gets emitted at the same point.

The SslOpts and corresponding TlsConnector are stored together in a struct in order to avoid accidentally mutating the SslOpts without clearing the connector.

I've also slightly refactored the no-TLS case to behave more uniformly with the rustls and native-tls implementations.