### PR TITLE
Explicitly rollback when transaction commit fails

### DIFF
--- a/src/queryable/transaction.rs
+++ b/src/queryable/transaction.rs
@@ -175,12 +175,24 @@ impl<'a> Transaction<'a> {
         Ok(Transaction(conn))
     }
 
-    /// Performs `COMMIT` query.
-    pub async fn commit(mut self) -> Result<()> {
+    /// Performs `COMMIT` query or returns an error
+    async fn try_commit(&mut self) -> Result<()> {
         let result = self.0.query_iter("COMMIT").await?;
         result.drop_result().await?;
         self.0.set_tx_status(TxStatus::None);
         Ok(())
+    }
+
+    /// Performs `COMMIT` query or rollbacks when any error occurs and returns the original error.
+    pub async fn commit(mut self) -> Result<()> {
+        match self.try_commit().await {
+            Ok(..) => Ok(()),
+            Err(e) =>  {
+                self.0.query_drop("ROLLBACK").await.unwrap_or(());
+                self.0.set_tx_status(TxStatus::None);
+                Err(e)
+            },
+        }
     }
 
     /// Performs `ROLLBACK` query.


### PR DESCRIPTION
The mysql server might return an error ("Transactions couldn't be nested"), because the previous commit failed and is not correctly rolled back.

Fixes https://github.com/blackbeam/mysql_async/issues/332