### PR TITLE
Fix connection count metrics

### DIFF
--- a/src/conn/pool/ttl_check_inerval.rs
+++ b/src/conn/pool/ttl_check_inerval.rs
@@ -70,6 +70,10 @@ impl TtlCheckInterval {
                 }
             }
             exchange.available = kept_available;
+            self.inner
+                .metrics
+                .connections_in_pool
+                .store(exchange.available.len(), Ordering::Relaxed);
             to_be_dropped
         };
 
@@ -79,6 +83,10 @@ impl TtlCheckInterval {
             tokio::spawn(idling_conn.conn.disconnect().then(move |_| {
                 let mut exchange = inner.exchange.lock().unwrap();
                 exchange.exist -= 1;
+                inner
+                    .metrics
+                    .connection_count
+                    .store(exchange.exist, Ordering::Relaxed);
                 ok::<_, ()>(())
             }));
         }


### PR DESCRIPTION
There were a few missing cases updating `connections_in_pool` / `connection_count` metrics.
I've fixed those and also changed them to always store the precise count
(either `exchange.exist` or `exchange.available.len()`), rather than using fetch_add/fetch_sub,
as the proper value is always known. No race condition is possible since we are under `exchange`'s lock.