### PR TITLE
Drop unused `webpki` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,11 +62,6 @@ optional = true
 version = "2.1.0"
 optional = true
 
-[dependencies.webpki]
-version = ">=0.22.1"
-features = ["std"]
-optional = true
-
 [dependencies.webpki-roots]
 version = "0.26.1"
 optional = true
@@ -103,7 +98,6 @@ native-tls-tls = ["native-tls", "tokio-native-tls"]
 rustls-tls = [
     "rustls",
     "tokio-rustls",
-    "webpki",
     "webpki-roots",
     "rustls-pemfile",
 ]

--- a/src/error/tls/rustls_error.rs
+++ b/src/error/tls/rustls_error.rs
@@ -7,8 +7,7 @@ use rustls::server::VerifierBuilderError;
 #[derive(Debug)]
 pub enum TlsError {
     Tls(rustls::Error),
-    Pki(webpki::Error),
-    InvalidDnsName(webpki::InvalidDnsNameError),
+    InvalidDnsName(rustls::pki_types::InvalidDnsNameError),
     VerifierBuilderError(VerifierBuilderError),
 }
 
@@ -30,15 +29,9 @@ impl From<rustls::Error> for TlsError {
     }
 }
 
-impl From<webpki::InvalidDnsNameError> for TlsError {
-    fn from(e: webpki::InvalidDnsNameError) -> Self {
+impl From<rustls::pki_types::InvalidDnsNameError> for TlsError {
+    fn from(e: rustls::pki_types::InvalidDnsNameError) -> Self {
         TlsError::InvalidDnsName(e)
-    }
-}
-
-impl From<webpki::Error> for TlsError {
-    fn from(e: webpki::Error) -> Self {
-        TlsError::Pki(e)
     }
 }
 
@@ -48,23 +41,10 @@ impl From<rustls::Error> for crate::Error {
     }
 }
 
-impl From<webpki::Error> for crate::Error {
-    fn from(e: webpki::Error) -> Self {
-        crate::Error::Io(crate::error::IoError::Tls(e.into()))
-    }
-}
-
-impl From<webpki::InvalidDnsNameError> for crate::Error {
-    fn from(e: webpki::InvalidDnsNameError) -> Self {
-        crate::Error::Io(crate::error::IoError::Tls(e.into()))
-    }
-}
-
 impl std::error::Error for TlsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             TlsError::Tls(e) => Some(e),
-            TlsError::Pki(e) => Some(e),
             TlsError::InvalidDnsName(e) => Some(e),
             TlsError::VerifierBuilderError(e) => Some(e),
         }
@@ -75,7 +55,6 @@ impl Display for TlsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TlsError::Tls(e) => e.fmt(f),
-            TlsError::Pki(e) => e.fmt(f),
             TlsError::InvalidDnsName(e) => e.fmt(f),
             TlsError::VerifierBuilderError(e) => e.fmt(f),
         }

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -85,7 +85,7 @@ impl Endpoint {
                 let stream = stream.take().unwrap();
 
                 let server_name = ServerName::try_from(domain.as_str())
-                    .map_err(|_| webpki::InvalidDnsNameError)?
+                    .map_err(TlsError::InvalidDnsName)?
                     .to_owned();
                 let connection = tls_connector.connect(server_name, stream).await?;
 


### PR DESCRIPTION
`webpki` is an unmaintained dependency. the rustls team forked it under `rustls-webpki`.
Meanwhile `rustls` changed their public API to not require the downstream user to also depend on `rustls-webpki` in most cases. This removes it from this crate as it's not needed.