### PR TITLE
Drop `pin-project` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ lru = "0.14.0"
 mysql_common = { version = "0.34", default-features = false }
 pem = "3.0"
 percent-encoding = "2.1.0"
-pin-project = "1.0.2"
 rand = "0.8.5"
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
While trying to replace `pin-project` with `pin-project-lite`,  a lightweight version of pin-project written with declarative macros, I've discovered that this project doesn't need either of them at all because all of the pin projections are done on [`Unpin`](https://doc.rust-lang.org/nightly/std/marker/trait.Unpin.html) types, which can already be manipulated without the aid of unsafe or `pin-project`/`pin-project-lite`. It's also very unlikely that it'll be needed in the future, as many libraries in the ecosystem expect networking types to be `Unpin`.