### PR TITLE
Replace `crossbeam` with `crossbeam-queue`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["asynchronous", "database"]
 
 [dependencies]
 bytes = "1.4"
-crossbeam = "0.8.1"
+crossbeam-queue = "0.3"
 flate2 = { version = "1.0", default-features = false }
 futures-core = "0.3"
 futures-util = "0.3"

--- a/src/buffer_pool.rs
+++ b/src/buffer_pool.rs
@@ -6,7 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use crossbeam::queue::ArrayQueue;
+use crossbeam_queue::ArrayQueue;
 use std::{mem::take, ops::Deref, sync::Arc};
 
 #[derive(Debug)]


### PR DESCRIPTION
As can be seen from the sources [^1], `crossbeam` is just a crate that re-exports the rest of the crates from their ecosystem. Given that this crate only needs `ArrayQueue`, I've decided to replace it with `crossbeam-queue`, the underlying implementation crate. This shoves off 4 more unused dependencies for me.

[^1]: https://docs.rs/crate/crossbeam/0.8.4/source/src/lib.rs