### PR TITLE
gen() compilation compilation warning

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1646,7 +1646,7 @@ mod test {
 
         fn random_pass() -> String {
             let mut rng = rand::rng();
-            let pass: [u8; 10] = rng.gen();
+            let pass: [u8; 10] = rng.random();
 
             IntoIterator::into_iter(pass)
                 .map(|x| ((x % (123 - 97)) + 97) as char)


### PR DESCRIPTION
Fix rng.gen() -> rng.random() compilation warning after upgrading rand to 0.9.