### PR TITLE
Make `ToConnection`, `Connection`, `ToConnectionResult` public

### DIFF
--- a/src/io/read_packet.rs
+++ b/src/io/read_packet.rs
@@ -37,7 +37,7 @@ impl Future for ReadPacket<'_, '_> {
     type Output = std::result::Result<PooledBuf, IoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let packet_opt = match self.0.stream_mut() {
+        let packet_opt = match self.0.as_mut().stream_mut() {
             Ok(stream) => ready!(Pin::new(stream).poll_next(cx)).transpose()?,
             // `ConnectionClosed` error.
             Err(_) => None,
@@ -45,7 +45,7 @@ impl Future for ReadPacket<'_, '_> {
 
         match packet_opt {
             Some(packet) => {
-                self.0.touch();
+                self.0.as_mut().touch();
                 Poll::Ready(Ok(packet))
             }
             None => Poll::Ready(Err(Error::new(

--- a/src/io/write_packet.rs
+++ b/src/io/write_packet.rs
@@ -44,7 +44,7 @@ impl Future for WritePacket<'_, '_> {
             ref mut data,
         } = *self;
 
-        match conn.stream_mut() {
+        match conn.as_mut().stream_mut() {
             Ok(stream) => {
                 if data.is_some() {
                     let codec = Pin::new(stream.codec.as_mut().expect("must be here"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,6 +569,8 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::queryable::Queryable;
     #[doc(inline)]
+    pub use crate::connection_like::{Connection, ToConnection, ToConnectionResult};
+    #[doc(inline)]
     pub use mysql_common::prelude::ColumnIndex;
     #[doc(inline)]
     pub use mysql_common::prelude::FromRow;
@@ -595,17 +597,6 @@ pub mod prelude {
     /// ```
     pub trait StatementLike: crate::queryable::stmt::StatementLike {}
     impl<T: crate::queryable::stmt::StatementLike> StatementLike for T {}
-
-    /// Everything that is a connection.
-    ///
-    /// Note that you could obtain a `'static` connection by giving away `Conn` or `Pool`.
-    pub trait ToConnection<'a, 't: 'a>: crate::connection_like::ToConnection<'a, 't> {}
-    // explicitly implemented because of rusdoc
-    impl<'a> ToConnection<'a, 'static> for &'a crate::Pool {}
-    impl ToConnection<'static, 'static> for crate::Pool {}
-    impl ToConnection<'static, 'static> for crate::Conn {}
-    impl<'a> ToConnection<'a, 'static> for &'a mut crate::Conn {}
-    impl<'a, 't> ToConnection<'a, 't> for &'a mut crate::Transaction<'t> {}
 
     /// Trait for protocol markers [`crate::TextProtocol`] and [`crate::BinaryProtocol`].
     pub trait Protocol: crate::queryable::Protocol {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,8 @@ pub mod futures {
 /// Traits used in this crate
 pub mod prelude {
     #[doc(inline)]
+    pub use crate::connection_like::{Connection, ToConnection, ToConnectionResult};
+    #[doc(inline)]
     pub use crate::local_infile_handler::GlobalHandler;
     #[doc(inline)]
     pub use crate::query::AsQuery;
@@ -568,8 +570,6 @@ pub mod prelude {
     pub use crate::query::{BatchQuery, Query, WithParams};
     #[doc(inline)]
     pub use crate::queryable::Queryable;
-    #[doc(inline)]
-    pub use crate::connection_like::{Connection, ToConnection, ToConnectionResult};
     #[doc(inline)]
     pub use mysql_common::prelude::ColumnIndex;
     #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,9 @@ pub use self::queryable::stmt::Statement;
 #[doc(inline)]
 pub use self::conn::pool::Metrics;
 
+#[doc(inline)]
+pub use crate::connection_like::{Connection, ToConnectionResult};
+
 /// Futures used in this crate
 pub mod futures {
     pub use crate::conn::pool::futures::{DisconnectPool, GetConn};
@@ -561,7 +564,7 @@ pub mod futures {
 /// Traits used in this crate
 pub mod prelude {
     #[doc(inline)]
-    pub use crate::connection_like::{Connection, ToConnection, ToConnectionResult};
+    pub use crate::connection_like::ToConnection;
     #[doc(inline)]
     pub use crate::local_infile_handler::GlobalHandler;
     #[doc(inline)]

--- a/src/queryable/query_result/result_set_stream.rs
+++ b/src/queryable/query_result/result_set_stream.rs
@@ -189,7 +189,7 @@ where
     async fn setup_stream(
         &mut self,
     ) -> crate::Result<Option<(Option<OkPacket<'static>>, Arc<[Column]>)>> {
-        match self.conn.use_pending_result()? {
+        match self.conn.as_mut().use_pending_result()? {
             Some(PendingResult::Taken(meta)) => {
                 let meta = (*meta).clone();
                 self.skip_taken(meta).await?;
@@ -199,7 +199,7 @@ where
         }
 
         let ok_packet = self.conn.last_ok_packet().cloned();
-        let columns = match self.conn.take_pending_result()? {
+        let columns = match self.conn.as_mut().take_pending_result()? {
             Some(meta) => meta.columns().clone(),
             None => return Ok(None),
         };


### PR DESCRIPTION
@smiera, hi!

This PR reopens your #338 — I've messed up updating your fork because of the `master` branch name being used and got "permission denied" as a result 😅

Please note that there is no `DerefMut<Target=Conn> for Transaction` because in general it is not correct to call `transaction.start_transaction()` — the good part is that `Connection` now implements `Queryable`.

This PR also adds `Connection::by_ref`