### PR TITLE
Don't use an arbitrary bound in histograms

### DIFF
--- a/src/conn/pool/metrics.rs
+++ b/src/conn/pool/metrics.rs
@@ -68,7 +68,7 @@ impl MetricsHistogram {
 #[cfg(feature = "hdrhistogram")]
 impl Default for MetricsHistogram {
     fn default() -> Self {
-        let hdr = hdrhistogram::Histogram::new_with_bounds(1, 30 * 1_000_000, 2).unwrap();
+        let hdr = hdrhistogram::Histogram::new(2).unwrap();
         Self(std::sync::Mutex::new(hdr))
     }
 }

--- a/src/conn/pool/recycler.rs
+++ b/src/conn/pool/recycler.rs
@@ -75,7 +75,8 @@ impl Recycler {
                 .connection_active_duration
                 .lock()
                 .unwrap()
-                .saturating_record(conn.inner.active_since.elapsed().as_micros() as u64);
+                .record(conn.inner.active_since.elapsed().as_micros() as u64)
+                .ok();
             exchange.available.push_back(conn.into());
             self.inner
                 .metrics


### PR DESCRIPTION
I hit this trying to figure out how an mostly idle server was reporting that no connection was idle for more than 30s.