### PR TITLE
Add connections in use metrics

### DIFF
--- a/src/conn/pool/metrics.rs
+++ b/src/conn/pool/metrics.rs
@@ -5,12 +5,14 @@ use serde::Serialize;
 #[derive(Default, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Metrics {
-    /// Guage of active connections to the database server, this includes both connections that have belong
+    /// Gauge of active connections to the database server, this includes both connections that have belong
     /// to the pool, and connections currently owned by the application.
     pub connection_count: AtomicUsize,
-    /// Guage of active connections that currently belong to the pool.
+    /// Gauge of active connections that currently belong to the pool.
     pub connections_in_pool: AtomicUsize,
-    /// Guage of GetConn requests that are currently active.
+    /// Gauge of active connections that are currently in use by the application (and not in the pool).
+    pub connections_in_use: AtomicUsize,
+    /// Gauge of GetConn requests that are currently active.
     pub active_wait_requests: AtomicUsize,
     /// Counter of connections that failed to be created.
     pub create_failed: AtomicUsize,

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -10,6 +10,13 @@ use futures_util::FutureExt;
 use keyed_priority_queue::KeyedPriorityQueue;
 use tokio::sync::mpsc;
 
+use crate::{
+    conn::{pool::futures::*, Conn},
+    error::*,
+    opts::{Opts, PoolOpts},
+    queryable::transaction::{Transaction, TxOpts},
+};
+use std::sync::atomic::Ordering;
 use std::{
     borrow::Borrow,
     cmp::Reverse,
@@ -19,13 +26,6 @@ use std::{
     sync::{atomic, Arc, Mutex},
     task::{Context, Poll, Waker},
     time::{Duration, Instant},
-};
-
-use crate::{
-    conn::{pool::futures::*, Conn},
-    error::*,
-    opts::{Opts, PoolOpts},
-    queryable::transaction::{Transaction, TxOpts},
 };
 
 pub use metrics::Metrics;
@@ -274,6 +274,10 @@ impl Pool {
     fn return_conn(&mut self, conn: Conn) {
         // NOTE: we're not in async context here, so we can't block or return NotReady
         // any and all cleanup work _has_ to be done in the spawned recycler
+        self.inner
+            .metrics
+            .connections_in_use
+            .fetch_sub(1, Ordering::Relaxed);
         self.send_to_recycler(conn);
     }
 
@@ -450,6 +454,10 @@ impl Drop for Conn {
         if std::thread::panicking() {
             // Try to decrease the number of existing connections.
             if let Some(pool) = self.inner.pool.take() {
+                pool.inner
+                    .metrics
+                    .connections_in_use
+                    .fetch_sub(1, Ordering::Relaxed);
                 pool.cancel_connection();
             }
 
@@ -1242,6 +1250,71 @@ mod test {
         fut3.await;
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn connection_in_use_metric() {
+        let pool = pool_with_one_connection();
+        let metrics = pool.metrics();
+
+        let conn = pool.get_conn().await.unwrap();
+        assert_eq!(
+            metrics
+                .connections_in_use
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+
+        drop(conn);
+        assert_eq!(
+            metrics
+                .connections_in_use
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+        loop {
+            if metrics
+                .connections_in_pool
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // Ensure that we increase the connections in use metric when we get a connection from the pool
+        let conn = pool.get_conn().await.unwrap();
+        assert_eq!(
+            metrics
+                .connections_in_use
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            metrics
+                .connections_in_pool
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+
+        drop(conn);
+        assert_eq!(
+            metrics
+                .connections_in_use
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+        loop {
+            if metrics
+                .connections_in_pool
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 
     #[cfg(feature = "nightly")]


### PR DESCRIPTION
The metric for connections that are currently being used by the client is missing. Ideally connection_count = connections_in_use + connections_in_pool