### PR TITLE
Hide DisconnectPool

### DIFF
--- a/src/conn/pool/futures/disconnect_pool.rs
+++ b/src/conn/pool/futures/disconnect_pool.rs
@@ -29,13 +29,13 @@ use std::sync::{atomic, Arc};
 /// are dropped or disonnected. Also all pending and new `GetConn`'s will resolve to error.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct DisconnectPool {
+struct DisconnectPool {
     pool_inner: Arc<Inner>,
     drop: Option<UnboundedSender<Option<Conn>>>,
 }
 
 impl DisconnectPool {
-    pub(crate) fn new(pool: Pool) -> Self {
+    fn new(pool: Pool) -> Self {
         Self {
             pool_inner: pool.inner,
             drop: Some(pool.drop),
@@ -72,4 +72,8 @@ impl Future for DisconnectPool {
             }
         }
     }
+}
+
+pub(crate) async fn disconnect_pool(pool: Pool) -> Result<(), Error> {
+    DisconnectPool::new(pool).await
 }

--- a/src/conn/pool/futures/mod.rs
+++ b/src/conn/pool/futures/mod.rs
@@ -6,8 +6,9 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+pub use self::get_conn::GetConn;
 pub(super) use self::get_conn::GetConnInner;
-pub use self::{disconnect_pool::DisconnectPool, get_conn::GetConn};
+pub(crate) use disconnect_pool::disconnect_pool;
 
 mod disconnect_pool;
 mod get_conn;

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -287,8 +287,8 @@ impl Pool {
     ///
     /// **Note:** This Future won't resolve until all active connections, taken from it,
     /// are dropped or disonnected. Also all pending and new `GetConn`'s will resolve to error.
-    pub fn disconnect(self) -> DisconnectPool {
-        DisconnectPool::new(self)
+    pub async fn disconnect(self) -> Result<()> {
+        disconnect_pool(self).await
     }
 
     /// A way to return connection taken from a pool.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,7 +558,7 @@ pub use crate::connection_like::{Connection, ToConnectionResult};
 
 /// Futures used in this crate
 pub mod futures {
-    pub use crate::conn::pool::futures::{DisconnectPool, GetConn};
+    pub use crate::conn::pool::futures::GetConn;
 }
 
 /// Traits used in this crate

--- a/tests/exports.rs
+++ b/tests/exports.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use mysql_async::{
     consts, from_row, from_row_opt, from_value, from_value_opt,
-    futures::{DisconnectPool, GetConn},
+    futures::GetConn,
     params,
     prelude::{
         BatchQuery, FromRow, FromValue, GlobalHandler, Protocol, Query, Queryable, StatementLike,


### PR DESCRIPTION
The only thing a user could do with it is await, so there is no need to expose the type.