### PR TITLE
Multiruntime pool warning (revert #387)

### DIFF
--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -121,6 +121,19 @@ pub struct Inner {
 ///
 /// Note that you will probably want to await [`Pool::disconnect`] before dropping the runtime, as
 /// otherwise you may end up with a number of connections that are not cleanly terminated.
+///
+/// ## Multi-runtime environments
+///
+/// `Pool` must not be shared across independent tokio runtimes. Each `tokio::net::TcpStream`
+/// inside a pooled connection is bound to the I/O driver of the runtime that established it;
+/// connections become invalid when that runtime shuts down. This is most likely to surface
+/// during graceful shutdown, when some runtimes exit before others while pooled connections
+/// are still in circulation. The pool's background tasks ([`Recycler`], TTL interval) are
+/// also spawned on the first runtime to call [`Pool::get_conn`] and do not survive that
+/// runtime's shutdown.
+///
+/// If your framework runs each worker on its own `current_thread` runtime (e.g. actix-server),
+/// create a separate `Pool` per worker rather than sharing one across all workers.
 #[derive(Debug, Clone)]
 pub struct Pool {
     opts: Opts,

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -121,12 +121,6 @@ pub struct Inner {
 ///
 /// Note that you will probably want to await [`Pool::disconnect`] before dropping the runtime, as
 /// otherwise you may end up with a number of connections that are not cleanly terminated.
-///
-/// ## Multi-runtime environments
-///
-/// In multi-runtime environments such as actix-web, the pool's background tasks must
-/// be explicitly started on the long-lived root runtime before worker runtimes begin
-/// using the pool. See [`Pool::spawn_background_tasks`] for details.
 #[derive(Debug, Clone)]
 pub struct Pool {
     opts: Opts,
@@ -167,38 +161,6 @@ impl Pool {
             }),
             drop: tx,
         }
-    }
-
-    /// Explicitly spawns the pool's background tasks on the current Tokio runtime.
-    ///
-    /// In most applications this method is unnecessary — the background tasks are spawned
-    /// automatically on the first call to [`Pool::get_conn`].
-    ///
-    /// # When to use this
-    ///
-    /// In multi-runtime environments (e.g., [actix-web](https://actix.rs/)), the lazy
-    /// spawning may cause the background tasks to be bound to a short-lived worker runtime
-    /// rather than the application's long-lived root runtime. When that worker runtime shuts
-    /// down, the [`Recycler`] is dropped, setting the pool's close flag and causing all
-    /// subsequent [`Pool::get_conn`] calls to return [`DriverError::PoolDisconnected`].
-    ///
-    /// Call this method once during startup, from within the long-lived runtime, before any
-    /// worker runtimes call [`Pool::get_conn`].
-    ///
-    /// **This method must be called from within the Tokio runtime that should own the
-    /// background tasks.**
-    ///
-    /// # Idempotency
-    ///
-    /// This method is a no-op after the first successful call.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called outside of a Tokio runtime context.
-    pub fn spawn_background_tasks(&self) {
-        let mut exchange = self.inner.exchange.lock().unwrap();
-
-        exchange.spawn_futures_if_needed(&self.inner);
     }
 
     /// Returns metrics for the connection pool.


### PR DESCRIPTION
I must apologize for my premature PR (#387). It was incorrect.

Although it fixed the "Pool was disconnected" problem, some connections still got the "A Tokio 1.x context was found, but it is being shutdown." Further debugging found that the I/O driver for the `TcpStream` stays with the runtime where the connection was started. And there doesn't seem to be any way around that. I don't think Pool is safe to share in a multi-runtime environment like actix-web. One Pool per worker works great, though it's more work to collect metrics.

I've reverted my previous commit and added a short section to the Pool documentation that warns about the situation.

Thanks for your patience!