### PR TITLE
fix: bump lru to 0.16.3 (RUSTSEC-2026-0002)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-core = "0.3"
 futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
-lru = "0.16.0"
+lru = "0.16.3"
 mysql_common = { version = "0.37.1", default-features = false }
 pem = { version = "3.0", optional = true }
 percent-encoding = "2.1.0"


### PR DESCRIPTION
`lru` 0.16.0 has a soundness issue in `IterMut` that violates Stacked Borrows (RUSTSEC-2026-0002).

Bumping to 0.16.3 which has the fix.

Reference : https://rustsec.org/advisories/RUSTSEC-2026-0002