### PR TITLE
Add Opts::after_connect callback

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -997,6 +997,10 @@ impl Conn {
     }
 
     async fn run_init_commands(&mut self) -> Result<()> {
+        if let Some(callback) = self.inner.opts.after_connect() {
+            callback.clone()(self).await?;
+        }
+
         let mut init = self.inner.opts.init().to_vec();
 
         while let Some(query) = init.pop() {
@@ -1382,8 +1386,13 @@ impl Conn {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use bytes::Bytes;
-    use futures_util::stream::{self, StreamExt};
+    use futures_util::{
+        stream::{self, StreamExt},
+        FutureExt,
+    };
     use mysql_common::constants::{MariadbCapabilities, MAX_PAYLOAD_LEN};
     use rand::RngExt as _;
     use tokio::{io::AsyncWriteExt, net::TcpListener};
@@ -1584,6 +1593,36 @@ mod test {
         let result: Vec<(u8, String)> = conn.query("SELECT @a, @b").await?;
         conn.disconnect().await?;
         assert_eq!(result, vec![(42, "foo".into())]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_execute_after_connect_callback_on_new_connection() -> super::Result<()> {
+        let opts = OptsBuilder::from_opts(get_opts()).after_connect(Arc::new(|conn| {
+            async move {
+                conn.query_drop("SET @a = 42").await?;
+                conn.query_drop("SET @b = 'foo'").await?;
+                Ok(())
+            }
+            .boxed()
+        }));
+        let mut conn = Conn::new(opts).await?;
+        let result: Vec<(u8, String)> = conn.query("SELECT @a, @b").await?;
+        conn.disconnect().await?;
+        assert_eq!(result, vec![(42, "foo".into())]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_propagate_after_connect_callback_error() -> super::Result<()> {
+        let opts = OptsBuilder::from_opts(get_opts()).after_connect(Arc::new(|_conn| {
+            async move { Err(Error::Other("rejected".into())) }.boxed()
+        }));
+        let e = Conn::new(opts).await.unwrap_err();
+        match e {
+            Error::Other(e) => assert_eq!(e.to_string(), "rejected"),
+            e => panic!("expected error from after_connect(), got {e:?}"),
+        }
         Ok(())
     }
 

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -998,7 +998,7 @@ impl Conn {
 
     async fn run_init_commands(&mut self) -> Result<()> {
         if let Some(callback) = self.inner.opts.after_connect() {
-            callback.clone()(self).await?;
+            callback(self).await?;
         }
 
         let mut init = self.inner.opts.init().to_vec();
@@ -1386,8 +1386,6 @@ impl Conn {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
     use bytes::Bytes;
     use futures_util::{
         stream::{self, StreamExt},
@@ -1598,14 +1596,14 @@ mod test {
 
     #[tokio::test]
     async fn should_execute_after_connect_callback_on_new_connection() -> super::Result<()> {
-        let opts = OptsBuilder::from_opts(get_opts()).after_connect(Arc::new(|conn| {
+        let opts = OptsBuilder::from_opts(get_opts()).after_connect(|conn| {
             async move {
                 conn.query_drop("SET @a = 42").await?;
                 conn.query_drop("SET @b = 'foo'").await?;
                 Ok(())
             }
             .boxed()
-        }));
+        });
         let mut conn = Conn::new(opts).await?;
         let result: Vec<(u8, String)> = conn.query("SELECT @a, @b").await?;
         conn.disconnect().await?;
@@ -1615,9 +1613,8 @@ mod test {
 
     #[tokio::test]
     async fn should_propagate_after_connect_callback_error() -> super::Result<()> {
-        let opts = OptsBuilder::from_opts(get_opts()).after_connect(Arc::new(|_conn| {
-            async move { Err(Error::Other("rejected".into())) }.boxed()
-        }));
+        let opts = OptsBuilder::from_opts(get_opts())
+            .after_connect(|_conn| async move { Err(Error::Other("rejected".into())) }.boxed());
         let e = Conn::new(opts).await.unwrap_err();
         match e {
             Error::Other(e) => assert_eq!(e.to_string(), "rejected"),

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -562,6 +562,25 @@ pub(crate) struct InnerOpts {
     address: HostPortOrUrl,
 }
 
+#[derive(Clone)]
+pub(crate) struct AfterConnectCallback(
+    Arc<dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync>,
+);
+
+impl Eq for AfterConnectCallback {}
+
+impl PartialEq for AfterConnectCallback {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl fmt::Debug for AfterConnectCallback {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AfterConnectCallback").finish()
+    }
+}
+
 /// Mysql connection options.
 ///
 /// Build one with [`OptsBuilder`].
@@ -594,6 +613,9 @@ pub(crate) struct MysqlOpts {
     /// Pool will close a connection if time since last IO exceeds this number of seconds
     /// (defaults to `wait_timeout`).
     conn_ttl: Option<Duration>,
+
+    /// Callback to execute once a new connection is established.
+    after_connect: Option<AfterConnectCallback>,
 
     /// Commands to execute once new connection is established.
     init: Vec<String>,
@@ -784,7 +806,18 @@ impl Opts {
         self.inner.mysql_opts.db_name.as_ref().map(AsRef::as_ref)
     }
 
-    /// Commands to execute once new connection is established.
+    /// Callback to execute after opening a new connection to the database. Runs
+    /// before the [`init`][Self::init] queries.
+    ///
+    /// If this returns an error, the connection attempt will also fail.
+    pub fn after_connect(
+        &self,
+    ) -> Option<&Arc<dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync>>
+    {
+        self.inner.mysql_opts.after_connect.as_ref().map(|cb| &cb.0)
+    }
+
+    /// Commands to execute once new a connection is established.
     pub fn init(&self) -> &[String] {
         self.inner.mysql_opts.init.as_ref()
     }
@@ -1143,6 +1176,7 @@ impl Default for MysqlOpts {
             user: None,
             pass: None,
             db_name: None,
+            after_connect: None,
             init: vec![],
             setup: vec![],
             tcp_keepalive: None,
@@ -1355,6 +1389,17 @@ impl OptsBuilder {
     /// Defines database name. See [`Opts::db_name`].
     pub fn db_name<T: Into<String>>(mut self, db_name: Option<T>) -> Self {
         self.opts.db_name = db_name.map(Into::into);
+        self
+    }
+
+    /// Defines a callback that runs after connection. See [`Opts::after_connect`].
+    pub fn after_connect(
+        mut self,
+        callback: Arc<
+            dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync,
+        >,
+    ) -> Self {
+        self.opts.after_connect = Some(AfterConnectCallback(callback));
         self
     }
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -562,22 +562,24 @@ pub(crate) struct InnerOpts {
     address: HostPortOrUrl,
 }
 
+/// This type alias is added to make clippy happy.
+type AfterConnectCallback =
+    Arc<dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync + 'static>;
+
 #[derive(Clone)]
-pub(crate) struct AfterConnectCallback(
-    Arc<dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync>,
-);
+pub(crate) struct AfterConnectCallbackWrapper(AfterConnectCallback);
 
-impl Eq for AfterConnectCallback {}
+impl Eq for AfterConnectCallbackWrapper {}
 
-impl PartialEq for AfterConnectCallback {
+impl PartialEq for AfterConnectCallbackWrapper {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
     }
 }
 
-impl fmt::Debug for AfterConnectCallback {
+impl fmt::Debug for AfterConnectCallbackWrapper {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("AfterConnectCallback").finish()
+        f.debug_tuple("AfterConnectCallbackWrapper").finish()
     }
 }
 
@@ -615,7 +617,7 @@ pub(crate) struct MysqlOpts {
     conn_ttl: Option<Duration>,
 
     /// Callback to execute once a new connection is established.
-    after_connect: Option<AfterConnectCallback>,
+    after_connect: Option<AfterConnectCallbackWrapper>,
 
     /// Commands to execute once new connection is established.
     init: Vec<String>,
@@ -810,11 +812,26 @@ impl Opts {
     /// before the [`init`][Self::init] queries.
     ///
     /// If this returns an error, the connection attempt will also fail.
-    pub fn after_connect(
-        &self,
-    ) -> Option<&Arc<dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync>>
-    {
-        self.inner.mysql_opts.after_connect.as_ref().map(|cb| &cb.0)
+    ///
+    /// ```no_run
+    /// use futures_util::FutureExt;
+    /// use mysql_async::OptsBuilder;
+    ///
+    /// let opts_builder: OptsBuilder = todo!();
+    ///
+    /// opts_builder.after_connect(|conn| {
+    ///     async move {
+    ///         // do something with `conn`
+    ///         Ok(())
+    ///     }.boxed()
+    /// });
+    /// ```
+    pub fn after_connect(&self) -> Option<AfterConnectCallback> {
+        self.inner
+            .mysql_opts
+            .after_connect
+            .as_ref()
+            .map(|cb| cb.0.clone())
     }
 
     /// Commands to execute once new a connection is established.
@@ -1393,13 +1410,11 @@ impl OptsBuilder {
     }
 
     /// Defines a callback that runs after connection. See [`Opts::after_connect`].
-    pub fn after_connect(
-        mut self,
-        callback: Arc<
-            dyn for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync,
-        >,
-    ) -> Self {
-        self.opts.after_connect = Some(AfterConnectCallback(callback));
+    pub fn after_connect<F>(mut self, callback: F) -> Self
+    where
+        F: for<'a> Fn(&'a mut crate::Conn) -> crate::BoxFuture<'a, ()> + Send + Sync + 'static,
+    {
+        self.opts.after_connect = Some(AfterConnectCallbackWrapper(Arc::new(callback)));
         self
     }
 


### PR DESCRIPTION
Similar to a feature of [sqlx](https://docs.rs/sqlx/0.8.6/sqlx/pool/struct.PoolOptions.html#method.after_connect).
I want so that I can check that I've connected to the right database (e.g. connected to a primary, not a replica).