### PR TITLE
Remove dependency on rustls-pemfile, use rustls::pki_types directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,13 +58,9 @@ version = "0.2"
 optional = true
 
 [dependencies.rustls]
-version = "0.23"
+version = "0.23.14"
 default-features = false
 features = ["std"]
-optional = true
-
-[dependencies.rustls-pemfile]
-version = "2.1.0"
 optional = true
 
 [dependencies.webpki-roots]
@@ -78,7 +74,7 @@ socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
-default = ["flate2/zlib", "derive"]
+default = ["flate2/zlib", "derive", "default-rustls"]
 
 default-rustls = ["default-rustls-no-provider", "aws-lc-rs"]
 
@@ -100,7 +96,7 @@ minimal-rust = ["flate2/rust_backend"]
 native-tls-tls = ["native-tls", "tokio-native-tls", "pem"]
 
 # rustls based TLS support
-rustls-tls = ["rustls", "tokio-rustls", "webpki-roots", "rustls-pemfile"]
+rustls-tls = ["rustls", "tokio-rustls", "webpki-roots"]
 
 aws-lc-rs = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs"]
 ring = ["rustls/ring", "tokio-rustls/ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
-default = ["flate2/zlib", "derive", "default-rustls"]
+default = ["flate2/zlib", "derive"]
 
 default-rustls = ["default-rustls-no-provider", "aws-lc-rs"]
 

--- a/src/error/tls/rustls_error.rs
+++ b/src/error/tls/rustls_error.rs
@@ -8,6 +8,7 @@ use rustls::server::VerifierBuilderError;
 pub enum TlsError {
     Tls(rustls::Error),
     InvalidDnsName(rustls::pki_types::InvalidDnsNameError),
+    InvalidPem(rustls::pki_types::pem::Error),
     VerifierBuilderError(VerifierBuilderError),
 }
 
@@ -35,8 +36,20 @@ impl From<rustls::pki_types::InvalidDnsNameError> for TlsError {
     }
 }
 
+impl From<rustls::pki_types::pem::Error> for TlsError {
+    fn from(e: rustls::pki_types::pem::Error) -> Self {
+        TlsError::InvalidPem(e)
+    }
+}
+
 impl From<rustls::Error> for crate::Error {
     fn from(e: rustls::Error) -> Self {
+        crate::Error::Io(crate::error::IoError::Tls(e.into()))
+    }
+}
+
+impl From<rustls::pki_types::pem::Error> for crate::Error {
+    fn from(e: rustls::pki_types::pem::Error) -> Self {
         crate::Error::Io(crate::error::IoError::Tls(e.into()))
     }
 }
@@ -46,6 +59,7 @@ impl std::error::Error for TlsError {
         match self {
             TlsError::Tls(e) => Some(e),
             TlsError::InvalidDnsName(e) => Some(e),
+            TlsError::InvalidPem(e) => Some(e),
             TlsError::VerifierBuilderError(e) => Some(e),
         }
     }
@@ -56,6 +70,7 @@ impl Display for TlsError {
         match self {
             TlsError::Tls(e) => e.fmt(f),
             TlsError::InvalidDnsName(e) => e.fmt(f),
+            TlsError::InvalidPem(e) => e.fmt(f),
             TlsError::VerifierBuilderError(e) => e.fmt(f),
         }
     }

--- a/src/error/tls/rustls_error.rs
+++ b/src/error/tls/rustls_error.rs
@@ -8,7 +8,7 @@ use rustls::server::VerifierBuilderError;
 pub enum TlsError {
     Tls(rustls::Error),
     InvalidDnsName(rustls::pki_types::InvalidDnsNameError),
-    InvalidPem(rustls::pki_types::pem::Error),
+    Pem(rustls::pki_types::pem::Error),
     VerifierBuilderError(VerifierBuilderError),
 }
 
@@ -38,7 +38,7 @@ impl From<rustls::pki_types::InvalidDnsNameError> for TlsError {
 
 impl From<rustls::pki_types::pem::Error> for TlsError {
     fn from(e: rustls::pki_types::pem::Error) -> Self {
-        TlsError::InvalidPem(e)
+        TlsError::Pem(e)
     }
 }
 
@@ -59,7 +59,7 @@ impl std::error::Error for TlsError {
         match self {
             TlsError::Tls(e) => Some(e),
             TlsError::InvalidDnsName(e) => Some(e),
-            TlsError::InvalidPem(e) => Some(e),
+            TlsError::Pem(e) => Some(e),
             TlsError::VerifierBuilderError(e) => Some(e),
         }
     }
@@ -70,7 +70,7 @@ impl Display for TlsError {
         match self {
             TlsError::Tls(e) => e.fmt(f),
             TlsError::InvalidDnsName(e) => e.fmt(f),
-            TlsError::InvalidPem(e) => e.fmt(f),
+            TlsError::Pem(e) => e.fmt(f),
             TlsError::VerifierBuilderError(e) => e.fmt(f),
         }
     }

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -5,11 +5,10 @@ use rustls::{
         danger::{ServerCertVerified, ServerCertVerifier},
         WebPkiServerVerifier,
     },
-    pki_types::{CertificateDer, ServerName},
+    pki_types::{pem, CertificateDer, ServerName},
     ClientConfig, RootCertStore,
 };
 
-use rustls_pemfile::certs;
 pub(crate) use tokio_rustls::TlsConnector;
 
 use crate::{io::Endpoint, Result, SslOpts, TlsError};
@@ -21,7 +20,7 @@ impl SslOpts {
         for root_cert in self.root_certs() {
             let root_cert_data = root_cert.read().await?;
             let mut seen = false;
-            for cert in certs(&mut &*root_cert_data) {
+            for cert in pem::SliceIter::<CertificateDer<'_>>::new(&root_cert_data) {
                 seen = true;
                 output.push(cert?);
             }

--- a/src/opts/rustls_opts.rs
+++ b/src/opts/rustls_opts.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "rustls-tls")]
 
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer};
-use rustls_pemfile::{certs, rsa_private_keys};
+use rustls::pki_types::{pem, CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer};
 
 use std::{borrow::Cow, path::Path};
 
@@ -60,7 +59,7 @@ impl ClientIdentity {
         if std::str::from_utf8(&cert_data).is_err() {
             cert_chain.push(CertificateDer::from(cert_data.into_owned()));
         } else {
-            for cert in certs(&mut &*cert_data) {
+            for cert in pem::SliceIter::<CertificateDer<'_>>::new(&cert_data) {
                 cert_chain.push(cert?);
             }
         }
@@ -71,7 +70,7 @@ impl ClientIdentity {
             )))
         } else {
             let mut priv_key = None;
-            for key in rsa_private_keys(&mut &*key_data).take(1) {
+            for key in pem::SliceIter::<PrivatePkcs1KeyDer<'_>>::new(&key_data).take(1) {
                 priv_key = Some(PrivateKeyDer::Pkcs1(key?.clone_key()));
             }
             priv_key


### PR DESCRIPTION
rustls-pemfile is deprecated and its functionality is available directly in rustls-pki-types.