### PR TITLE
Porting of the support of MariaDB metadata skip option from mysql_simple

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["asynchronous", "database"]
 [dependencies]
 bytes = "1.4"
 crossbeam-queue = "0.3"
+crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 futures-core = "0.3"
 futures-util = "0.3"

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -2616,6 +2616,146 @@ mod test {
         }
     }
 
+    // This test verifies that the metadata is correct with or without metadata caching, and that protocol
+    // is not broken afterwards and data is read correctly. It doesn't test that the metadata is really cached
+    // (if that is possible) and not received twice.
+    #[tokio::test]
+    async fn test_metadata_caching() {
+        use crate::consts::ColumnType;
+        let mut conn = Conn::new(get_opts()).await.unwrap();
+        if !conn.inner.is_mariadb {
+            return;
+        }
+
+        conn.query_drop(
+            r"CREATE TEMPORARY TABLE t_metadata_caching (
+                id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+                val VARCHAR(32) NOT NULL)",
+        )
+        .await
+        .unwrap();
+
+        // Populating table with some data to verify that data still fetched correctly with cached metadata use
+        let insert_stmt = conn
+            .prep("INSERT INTO t_metadata_caching (val) VALUES (?)")
+            .await
+            .unwrap();
+        let _ = conn.exec_drop(&insert_stmt, ("AAA",)).await;
+        let _ = conn.exec_drop(&insert_stmt, ("BB",)).await;
+        let mut ps = conn
+            .prep("SELECT id, val FROM t_metadata_caching")
+            .await
+            .unwrap();
+
+        let mut columns_from_prep = ps.columns();
+        let mut metadata_from_prep: Vec<(String, ColumnType)> = columns_from_prep
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect();
+
+        let mut query_result = conn.exec_iter(&ps, ()).await.unwrap();
+        let mut columns_from_exec1 = query_result.columns().unwrap();
+        let mut metadata_from_exec1: Vec<(String, ColumnType)> = columns_from_exec1
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect();
+
+        // Comparing and verifying metadata.
+        assert_eq!(metadata_from_prep, metadata_from_exec1);
+        assert_eq!(metadata_from_prep.len(), 2);
+        assert_eq!(metadata_from_prep[0].0, "id");
+        assert_eq!(metadata_from_prep[0].1, ColumnType::MYSQL_TYPE_LONG);
+        assert_eq!(metadata_from_prep[1].0, "val");
+        assert_eq!(metadata_from_prep[1].1, ColumnType::MYSQL_TYPE_VAR_STRING);
+
+        let fetched_rows: Vec<(i32, String)> = query_result.collect().await.unwrap();
+
+        let expected_rows = [(1, "AAA".to_string()), (2, "BB".to_string())];
+        assert_eq!(fetched_rows.len(), expected_rows.len());
+
+        for (fetched, expected) in fetched_rows.iter().zip(expected_rows.iter()) {
+            assert_eq!(fetched, expected);
+        }
+
+        // Doing the same for exec_first. Technically it's internally the same as exec_iter,
+        // but the test isn't supposed to know that and to test it
+        ps = conn
+            .prep("SELECT val FROM t_metadata_caching WHERE id = ?")
+            .await
+            .unwrap();
+        columns_from_prep = ps.columns();
+        metadata_from_prep = columns_from_prep
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect();
+        let single_row: Option<String> = conn.exec_first(&ps, (1,)).await.unwrap();
+        if let Some(val) = single_row {
+            assert_eq!(metadata_from_prep.len(), 1);
+            assert_eq!(metadata_from_prep[0].0, "val");
+            assert_eq!(metadata_from_prep[0].1, ColumnType::MYSQL_TYPE_VAR_STRING);
+
+            assert_eq!(val, "AAA".to_string());
+        }
+        // Testing the case when metadata is changed after execution
+        ps = conn.prep("SELECT ?").await.unwrap();
+
+        columns_from_prep = ps.columns();
+        metadata_from_prep = columns_from_prep
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect();
+
+        // First query — server sends metadata because the type has changed
+        query_result = conn.exec_iter(&ps, (12,)).await.unwrap();
+        columns_from_exec1 = query_result.columns().unwrap();
+        metadata_from_exec1 = columns_from_exec1
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect();
+        let fetched_rows: Vec<i32> = query_result.collect().await.unwrap();
+
+        // Second query — server skips metadata packets
+        query_result = conn.exec_iter(&ps, (42,)).await.unwrap();
+        let columns_from_exec2 = query_result.columns().unwrap();
+        let metadata_from_exec2 = columns_from_exec2
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect::<Vec<_>>();
+        let fetched_rows2: Vec<i32> = query_result.collect().await.unwrap();
+
+        // Third query — server sends metadata because the type has changed
+        query_result = conn.exec_iter(&ps, ("foo",)).await.unwrap();
+        let columns_from_exec3 = query_result.columns().unwrap();
+        let metadata_from_exec3 = columns_from_exec3
+            .iter()
+            .map(|column| (column.name_str().to_string(), column.column_type()))
+            .collect::<Vec<_>>();
+        let fetched_rows3: Vec<String> = query_result.collect().await.unwrap();
+
+        // Comparing and verifying metadata.
+        assert_eq!(metadata_from_exec1.len(), 1);
+        assert_eq!(metadata_from_exec2.len(), 1);
+        assert_eq!(metadata_from_exec3.len(), 1);
+        assert_eq!(metadata_from_prep.len(), 1);
+        assert_eq!(metadata_from_prep[0].0, "?");
+        assert!(
+            metadata_from_prep[0].1 == ColumnType::MYSQL_TYPE_NULL
+                || metadata_from_prep[0].1 == ColumnType::MYSQL_TYPE_VAR_STRING,
+            "Expected MYSQL_TYPE_NULL(MariaDB) or MYSQL_TYPE_VAR_STRING(MySQL), got {:?}",
+            metadata_from_prep[0].1
+        );
+        assert_eq!(metadata_from_exec1[0].0, "?");
+        assert_eq!(metadata_from_exec1[0].1, ColumnType::MYSQL_TYPE_LONGLONG);
+        assert_eq!(metadata_from_exec2[0].0, "?");
+        assert_eq!(metadata_from_exec2[0].1, ColumnType::MYSQL_TYPE_LONGLONG);
+        assert_eq!(metadata_from_exec3[0].0, "?");
+        assert_eq!(metadata_from_exec3[0].1, ColumnType::MYSQL_TYPE_VAR_STRING);
+
+        assert_eq!(fetched_rows[0], 12);
+        assert_eq!(fetched_rows2[0], 42);
+        assert_eq!(fetched_rows3[0], "foo".to_owned());
+    }
+
     #[cfg(feature = "nightly")]
     mod bench {
         use crate::{conn::Conn, queryable::Queryable, test_misc::get_opts};

--- a/src/conn/routines/exec.rs
+++ b/src/conn/routines/exec.rs
@@ -82,7 +82,8 @@ impl Routine<()> for ExecRoutine<'_> {
             }
 
             conn.write_command(&body).await?;
-            conn.read_result_set::<BinaryProtocol>(true).await?;
+            conn.read_result_set::<BinaryProtocol>(true, Some(self.stmt))
+                .await?;
 
             Ok(())
         };
@@ -142,7 +143,8 @@ where
             for command in builder.build_params_iter(params) {
                 let command = command.map_err(crate::DriverError::from)?;
                 conn.write_command(&command).await?;
-                conn.read_result_set::<BinaryProtocol>(true).await?;
+                conn.read_result_set::<BinaryProtocol>(true, Some(stmt))
+                    .await?;
                 let query_result = QueryResult::<'_, '_, BinaryProtocol>::new(&mut *conn);
                 query_result.drop_result().await?;
             }

--- a/src/conn/routines/helpers.rs
+++ b/src/conn/routines/helpers.rs
@@ -10,7 +10,7 @@ use mysql_common::{
     value::Value,
 };
 
-use crate::{error::LocalInfileError, queryable::Protocol, Conn, Error};
+use crate::{error::LocalInfileError, queryable::Protocol, Conn, Error, Statement};
 
 impl Conn {
     /// Helper, that sends all `Value::Bytes` in the given list of paramenters as long data.
@@ -44,6 +44,7 @@ impl Conn {
     pub(super) async fn read_result_set<P>(
         &mut self,
         is_first_result_set: bool,
+        stmt: Option<&Statement>,
     ) -> crate::Result<()>
     where
         P: Protocol,
@@ -72,7 +73,7 @@ impl Conn {
                 ))))?;
             }
             Some(0xFB) => self.handle_local_infile::<P>(&packet).await?,
-            _ => self.handle_result_set::<P>(&packet).await?,
+            _ => self.handle_result_set::<P>(&packet, stmt).await?,
         }
 
         Ok(())
@@ -122,13 +123,28 @@ impl Conn {
     /// Helper that handles result set packet.
     ///
     /// Requires that `packet` contains non-zero length-encoded integer.
-    pub(super) async fn handle_result_set<P>(&mut self, mut packet: &[u8]) -> crate::Result<()>
+    pub(super) async fn handle_result_set<P>(
+        &mut self,
+        mut packet: &[u8],
+        stmt: Option<&Statement>,
+    ) -> crate::Result<()>
     where
         P: Protocol,
     {
         let column_count = packet.read_lenenc_int()?;
-        let columns = self.read_column_defs(column_count as usize).await?;
-        let meta = P::result_set_meta(Arc::from(columns.into_boxed_slice()));
+        // Reading 1st byte only if metadata skip is not possible, otherwise it can be a part of the first column definition.
+        // Reading column metadata only if it is not skipped - if skip is not possible or if metadata is present.
+        let meta = if !(P::metadata_skip_possible(self) && packet.first() == Some(&0x00)) {
+            let columns = self.read_column_defs(column_count as usize).await?;
+            // Statement must have latest version of the metadata.
+            if let Some(stmt) = stmt {
+                stmt.update_columns_metadata(columns.clone());
+            }
+            P::result_set_meta(Arc::from(columns.into_boxed_slice()))
+        } else {
+            // Since metadata is skipped, stmt must be present.
+            P::result_set_meta(Arc::from(stmt.unwrap().columns()))
+        };
         self.set_pending_result(Some(meta))?;
         Ok(())
     }

--- a/src/conn/routines/next_set.rs
+++ b/src/conn/routines/next_set.rs
@@ -34,7 +34,9 @@ where
         );
         conn.sync_seq_id();
         let fut = async move {
-            conn.read_result_set::<P>(false).await?;
+            // Cached metadata can be for binary protocol only. With binary we can't have a batch prepared. Multiple results
+            // are only possible with SP call. But with them we won't have metadata skipped(on 2nd or more result).
+            conn.read_result_set::<P>(false, None).await?;
             Ok(())
         };
 

--- a/src/conn/routines/query.rs
+++ b/src/conn/routines/query.rs
@@ -52,7 +52,7 @@ impl<L: TracingLevel> Routine<()> for QueryRoutine<'_, L> {
         let fut = async move {
             conn.write_command_data(Command::COM_QUERY, self.data)
                 .await?;
-            conn.read_result_set::<TextProtocol>(true).await?;
+            conn.read_result_set::<TextProtocol>(true, None).await?;
             Ok(())
         };
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -1129,6 +1129,7 @@ impl Opts {
 
     pub(crate) fn get_mariadb_capabilities(&self) -> MariadbCapabilities {
         MariadbCapabilities::MARIADB_CLIENT_STMT_BULK_OPERATIONS
+            | MariadbCapabilities::MARIADB_CLIENT_CACHE_METADATA
             | MariadbCapabilities::MARIADB_CLIENT_BULK_UNIT_RESULTS
     }
 

--- a/src/queryable/mod.rs
+++ b/src/queryable/mod.rs
@@ -49,6 +49,7 @@ pub trait Protocol: fmt::Debug + Send + Sync + 'static {
             packet[0] == 0xFE && packet.len() < 8
         }
     }
+    fn metadata_skip_possible(conn: &Conn) -> bool;
 }
 
 /// Phantom struct used to specify MySql text protocol.
@@ -70,6 +71,10 @@ impl Protocol for TextProtocol {
             .map(Into::into)
             .map_err(Into::into)
     }
+
+    fn metadata_skip_possible(_conn: &Conn) -> bool {
+        false
+    }
 }
 
 impl Protocol for BinaryProtocol {
@@ -82,6 +87,10 @@ impl Protocol for BinaryProtocol {
             .parse::<RowDeserializer<ServerSide, Binary>>(columns)
             .map(Into::into)
             .map_err(Into::into)
+    }
+
+    fn metadata_skip_possible(conn: &Conn) -> bool {
+        conn.has_mariadb_capabilities(MariadbCapabilities::MARIADB_CLIENT_CACHE_METADATA)
     }
 }
 

--- a/src/queryable/stmt.rs
+++ b/src/queryable/stmt.rs
@@ -6,6 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use crossbeam_utils::atomic::AtomicCell;
 use futures_util::FutureExt;
 use mysql_common::{
     io::ParseBuf,
@@ -13,7 +14,7 @@ use mysql_common::{
     packets::{ComStmtClose, StmtPacket},
 };
 
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, fmt, ptr::NonNull, sync::Arc};
 
 use crate::{
     conn::routines::{ExecBulkRoutine, ExecRoutine, PrepareRoutine},
@@ -175,10 +176,14 @@ impl<T: StatementLike + Clone> StatementLike for &'_ T {
 }
 
 /// Statement data.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StmtInner {
     pub(crate) raw_query: Arc<[u8]>,
-    columns: Option<Box<[Column]>>,
+    columns: Option<Arc<[Column]>>,
+    /// This cached value overrides the column metadata stored in the `inner` field.
+    ///
+    /// See MARIADB_CLIENT_CACHE_METADATA capability.
+    columns_cache: ColumnCache,
     params: Option<Box<[Column]>>,
     stmt_packet: StmtPacket,
     connection_id: u32,
@@ -195,6 +200,7 @@ impl StmtInner {
         Ok(Self {
             raw_query,
             columns: None,
+            columns_cache: ColumnCache::new(),
             params: None,
             stmt_packet,
             connection_id,
@@ -214,13 +220,20 @@ impl StmtInner {
         self.columns = if columns.is_empty() {
             None
         } else {
-            Some(columns.into_boxed_slice())
+            Some(Arc::from(columns))
         };
         self
     }
 
-    pub(crate) fn columns(&self) -> &[Column] {
-        self.columns.as_ref().map(AsRef::as_ref).unwrap_or(&[])
+    pub(crate) fn columns(&self) -> Arc<[Column]> {
+        self.columns_cache
+            .get_columns()
+            .or_else(|| self.columns.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn update_columns_metadata(&self, columns: Vec<Column>) {
+        self.columns_cache.set_columns(columns);
     }
 
     pub(crate) fn params(&self) -> &[Column] {
@@ -263,8 +276,15 @@ impl Statement {
     }
 
     /// Returned columns.
-    pub fn columns(&self) -> &[Column] {
+    pub fn columns(&self) -> Arc<[Column]> {
         self.inner.columns()
+    }
+
+    /// Overrides columns metadata for this statement.
+    ///
+    /// See MARIADB_CLIENT_CACHE_METADATA capability.
+    pub(crate) fn update_columns_metadata(&self, columns: Vec<Column>) {
+        self.inner.update_columns_metadata(columns);
     }
 
     /// Required parameters.
@@ -377,5 +397,91 @@ impl crate::Conn {
     pub(crate) async fn close_statement(&mut self, id: u32) -> Result<()> {
         self.stmt_cache_mut().remove(id);
         self.write_command(&ComStmtClose::new(id)).await
+    }
+}
+
+/// This is to make raw Arc pointer Send and Sync
+///
+/// This splits fat `*const [Column]` pointer to its components
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+struct ColumnsArcPtr((NonNull<Column>, usize));
+
+impl ColumnsArcPtr {
+    fn from_arc(arc: Arc<[Column]>) -> Self {
+        let len = arc.len();
+        let ptr = Arc::into_raw(arc);
+        // SAFETY: the `Arc` structure itself contains NonNull so this is either safe
+        // or someone created a broken `Arc` using unsafe code.
+        let ptr = unsafe { NonNull::new_unchecked(ptr as *const Column as *mut Column) };
+        Self((ptr, len))
+    }
+
+    fn to_arc(self) -> Arc<[Column]> {
+        let columns = self.into_arc();
+        let clone = columns.clone();
+        // ignore the pointer because it is already stored in self
+        let _ = Arc::into_raw(columns);
+        clone
+    }
+
+    fn into_arc(self) -> Arc<[Column]> {
+        let fat_pointer = NonNull::slice_from_raw_parts(self.0 .0, self.0 .1);
+        // SAFETY: non-null pointer always points to a valid Arc
+        unsafe { Arc::from_raw(fat_pointer.as_ptr()) }
+    }
+}
+
+unsafe impl Send for ColumnsArcPtr {}
+unsafe impl Sync for ColumnsArcPtr {}
+
+struct ColumnCache {
+    columns: AtomicCell<Option<ColumnsArcPtr>>,
+}
+
+impl ColumnCache {
+    fn new() -> Self {
+        Self {
+            columns: AtomicCell::new(None),
+        }
+    }
+
+    fn get_columns(&self) -> Option<Arc<[Column]>> {
+        self.columns.load().map(|x| x.to_arc())
+    }
+
+    fn set_columns(&self, new_columns: Vec<Column>) {
+        let new_columns: Arc<[Column]> = new_columns.into();
+        let new_ptr = ColumnsArcPtr::from_arc(new_columns);
+
+        let Some(old_ptr) = self.columns.swap(Some(new_ptr)) else {
+            return;
+        };
+
+        // drop the old `Arc`
+        old_ptr.into_arc();
+    }
+}
+
+impl fmt::Debug for ColumnCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ColumnCache")
+            .field("columns", &self.get_columns())
+            .finish()
+    }
+}
+
+impl PartialEq for ColumnCache {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_columns() == other.get_columns()
+    }
+}
+
+impl Eq for ColumnCache {}
+
+impl Drop for ColumnCache {
+    fn drop(&mut self) {
+        // drop `Arc` if any
+        self.columns.load().map(|x| x.into_arc());
     }
 }


### PR DESCRIPTION
The patch add setting of corresponding MariaDB capability, skips reading of the metadata if it's not present, updating of the cached metadata in the Statement, if it's present. For that purpose Statement object is passed to the methods reading metadata and the method to tell if skipping is possible has been added to the Protocol.

The testcase has been also ported.