### PR TITLE
feature: add `compose.yaml` for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,10 +386,27 @@ pool.disconnect().await?;
 
 ## Testing
 
-Tests uses followin environment variables:
+### Quickstart
+
+If you have a container engine such as Podman or Docker, you can run the tests
+using the provided `compose.yaml` configuration file.
+* Docker
+  ```sh
+  docker compose up --wait && cargo test -- --test-threads=1; docker compose down
+  ```
+* Podman (requires `podman-compose` 1.6.0 or later)
+  ```sh
+  podman compose up --wait && cargo test -- --test-threads=1; podman compose down
+  ```
+
+### Configuration
+
+Tests uses following environment variables:
 * `DATABASE_URL` – defaults to `mysql://root:password@127.0.0.1:3307/mysql`
 * `COMPRESS` – set to `1` or `true` to enable compression for tests
 * `SSL` – set to `1` or `true` to enable TLS for tests
+
+### Manual container
 
 You can run a test server using docker. Please note that params related
 to max allowed packet, local-infile and binary logging are required

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,48 @@
+# Compose file to spin up a test environment.
+#
+# This file is compatible with both `docker compose` and `podman compose`.
+#
+# Start in the foreground, stop with the interupt signal (^C).
+# ```
+# # Docker
+# docker compose up
+# # Podman
+# podman compose up
+# ```
+#
+# Start in the background, then stop it
+# ```
+# # Docker
+# docker compose up --wait
+# docker compose down
+# # Podman (requires podman-compose 1.6.0 or later)
+# podman compose up --wait
+# podman compose down
+# ```
+
+services:
+  mariadb:
+    image: "docker.io/library/mariadb:10.6.20@sha256:0ba11696aa4be8d463eaf2316212ffb1e0fb4a4430b2fff076eb518c8a1328e1"
+    command: [
+      "--max_connections=1000",
+      # required for the test `conn::test::should_change_user`
+      "--secure-auth=false",
+      # required for the test `conn::test::should_perform_queries`
+      "--max-allowed-packet=36700160",
+    ]
+    environment: [
+       # required for Linux hosts
+      "UMASK=0777",
+       # required for Linux hosts
+      "UMASK_DIR=0777",
+      "MARIADB_ROOT_PASSWORD=password",
+      "MARIADB_DATABASE=mysql",
+    ]
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: "/usr/bin/mysql --user=root --password=password --execute \"show databases;\""
+      interval: "3s"
+      start_period: "3s"
+      timeout: "3s"
+      retries: 10


### PR DESCRIPTION
This commit adds a `compose.yaml` to provide an environment to execute tests locally. It is verified to work with both Podman and Docker. It is provided as a simpler alternative to manual configuration of a test database.