### PR TITLE
Support sha256_password via AuthProc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
 lru = "0.18"
-# Temporary git pin while mysql_common 0.38.0 is under review in
-# blackbeam/rust_mysql_common#186. Replace with the released version afterwards.
-mysql_common = { git = "https://github.com/t8y2/rust_mysql_common.git", rev = "77085e91e5081309d585153e3b656ce33bc1fe74", default-features = false }
+mysql_common = { version = "0.38.2", default-features = false }
 pem = { version = "3.0", optional = true }
 percent-encoding = "2.1.0"
 rand = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
 lru = "0.18"
-mysql_common = { version = "0.37.1", default-features = false }
+# Temporary git pin while mysql_common 0.38.0 is under review in
+# blackbeam/rust_mysql_common#186. Replace with the released version afterwards.
+mysql_common = { git = "https://github.com/t8y2/rust_mysql_common.git", rev = "77085e91e5081309d585153e3b656ce33bc1fe74", default-features = false }
 pem = { version = "3.0", optional = true }
 percent-encoding = "2.1.0"
 rand = "0.10"

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -22,6 +22,7 @@ use mysql_common::{
     proto::MySerialize,
     row::Row,
 };
+use tokio::{fs::File, io::AsyncReadExt as _};
 
 use std::{
     borrow::Cow,
@@ -153,7 +154,10 @@ struct ConnInner {
     stmt_cache: StmtCache,
     nonce: Vec<u8>,
     auth_plugin: AuthPlugin<'static>,
-    server_key: Option<Vec<u8>>,
+
+    // Cached public server key used for RSA-based key exchange by the caching_sha2_password plugin.
+    server_key_pem: Option<Option<Vec<u8>>>,
+
     active_since: Instant,
     /// Connection is already disconnected.
     pub(crate) disconnected: bool,
@@ -172,7 +176,7 @@ impl fmt::Debug for ConnInner {
             .field("tx_status", &self.tx_status)
             .field("stream", &self.stream)
             .field("options", &self.opts)
-            .field("server_key", &self.server_key)
+            .field("server_key_pem", &self.server_key_pem)
             .field("auth_plugin", &self.auth_plugin)
             .field("capabilities", &self.capabilities)
             .field("mariadb_capabilities", &self.mariadb_capabilities)
@@ -207,7 +211,7 @@ impl ConnInner {
             nonce: Vec::default(),
             auth_plugin: AuthPlugin::MysqlNativePassword,
             disconnected: false,
-            server_key: None,
+            server_key_pem: None,
             infile_handler: None,
             reset_upon_returning_to_a_pool: false,
             active_since: Instant::now(),
@@ -632,8 +636,20 @@ impl Conn {
         }
     }
 
-    fn auth_context(&self) -> AuthContext {
-        AuthContext {
+    async fn auth_context(&mut self) -> crate::Result<AuthContext> {
+        // cache server key
+        if self.inner.server_key_pem.is_none() {
+            if let Some(server_key_path) = self.inner.opts.server_key_path() {
+                let mut server_key_data = vec![];
+                let mut server_key_file = File::open(server_key_path).await?;
+                server_key_file.read_to_end(&mut server_key_data).await?;
+                self.inner.server_key_pem = Some(Some(server_key_data));
+            } else {
+                self.inner.server_key_pem = Some(None);
+            }
+        }
+
+        Ok(AuthContext {
             pass: self
                 .inner
                 .opts
@@ -644,11 +660,11 @@ impl Conn {
             is_ipc_transport: self.is_socket(),
             is_tls_transport: self.is_secure(),
             scramble: self.inner.nonce.clone(),
-            server_key_pem: self.inner.server_key.clone(),
-        }
+            server_key_pem: self.inner.server_key_pem.as_ref().and_then(|x| x.clone()),
+        })
     }
 
-    fn start_auth(&self, plugin: &AuthPlugin<'_>, challenge: &[u8]) -> Result<AuthState> {
+    async fn start_auth(&mut self, plugin: &AuthPlugin<'_>, challenge: &[u8]) -> Result<AuthState> {
         if matches!(plugin, AuthPlugin::MysqlOldPassword) && self.inner.opts.secure_auth() {
             return Err(DriverError::MysqlOldPasswordDisabled.into());
         }
@@ -658,7 +674,7 @@ impl Conn {
             return Err(DriverError::CleartextPluginDisabled.into());
         }
 
-        let context = self.auth_context();
+        let context = self.auth_context().await?;
         let mut procedure = plugin.init().map_err(DriverError::from)?;
         let response = procedure
             .run(&context, challenge)
@@ -669,7 +685,7 @@ impl Conn {
     async fn do_handshake_response(&mut self) -> Result<AuthState> {
         let plugin = self.inner.auth_plugin.clone();
         let nonce = self.inner.nonce.clone();
-        let state = self.start_auth(&plugin, &nonce)?;
+        let state = self.start_auth(&plugin, &nonce).await?;
 
         let handshake_response = HandshakeResponse::new(
             state.2.data(),
@@ -698,10 +714,12 @@ impl Conn {
         &mut self,
         auth_switch_request: AuthSwitchRequest<'_>,
     ) -> Result<AuthState> {
-        let state = self.start_auth(
-            &auth_switch_request.auth_plugin(),
-            auth_switch_request.plugin_data(),
-        )?;
+        let state = self
+            .start_auth(
+                &auth_switch_request.auth_plugin(),
+                auth_switch_request.plugin_data(),
+            )
+            .await?;
         if let Some(data) = state.2.data() {
             self.write_bytes(data).await?;
         }
@@ -741,14 +759,14 @@ impl Conn {
             let challenge = packet.strip_prefix(b"\x01").unwrap_or(&packet);
 
             // cache server key if needed
-            if self.inner.server_key.is_none()
+            if self.inner.server_key_pem.is_none()
                 && ((matches!(procedure, AuthProc::CachingSha2Password(_))
                     && previous_response.data() == Some(&[0x02]))
                     || (matches!(procedure, AuthProc::Sha256Password(_))
                         && previous_response.data() == Some(&[0x01])))
                 && challenge.starts_with(b"-----BEGIN")
             {
-                self.inner.server_key = Some(challenge.to_vec());
+                self.inner.server_key_pem = Some(Some(challenge.to_vec()));
             }
 
             match previous_response {

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -9,10 +9,10 @@
 use futures_util::FutureExt;
 
 use mysql_common::{
+    auth::{self, plugins::ChallengeResponsePlugin as _},
     constants::{
         MariadbCapabilities, DEFAULT_MAX_ALLOWED_PACKET, UTF8MB4_GENERAL_CI, UTF8_GENERAL_CI,
     },
-    crypto,
     io::ParseBuf,
     packets::{
         AuthPlugin, AuthSwitchRequest, CommonOkPacket, ErrPacket, HandshakePacket,
@@ -58,6 +58,42 @@ pub mod routines;
 pub mod stmt_cache;
 
 const DEFAULT_WAIT_TIMEOUT: usize = 28800;
+
+type AuthState = (
+    AuthContext,
+    auth::plugins::AuthProc,
+    auth::plugins::Response,
+);
+
+struct AuthContext {
+    pass: Vec<u8>,
+    is_ipc_transport: bool,
+    is_tls_transport: bool,
+    scramble: Vec<u8>,
+    server_key_pem: Option<Vec<u8>>,
+}
+
+impl auth::plugins::Context for &'_ AuthContext {
+    fn pass(&self) -> &[u8] {
+        &self.pass
+    }
+
+    fn is_ipc_transport(&self) -> bool {
+        self.is_ipc_transport
+    }
+
+    fn is_tls_transport(&self) -> bool {
+        self.is_tls_transport
+    }
+
+    fn scramble(&self) -> &[u8] {
+        &self.scramble
+    }
+
+    fn server_key_pem(&self) -> Option<&[u8]> {
+        self.server_key_pem.as_deref()
+    }
+}
 
 /// Helper that asynchronously disconnects the given connection on the default tokio executor.
 fn disconnect(mut conn: Conn) {
@@ -117,7 +153,6 @@ struct ConnInner {
     stmt_cache: StmtCache,
     nonce: Vec<u8>,
     auth_plugin: AuthPlugin<'static>,
-    auth_switched: bool,
     server_key: Option<Vec<u8>>,
     active_since: Instant,
     /// Connection is already disconnected.
@@ -171,7 +206,6 @@ impl ConnInner {
             ttl_deadline,
             nonce: Vec::default(),
             auth_plugin: AuthPlugin::MysqlNativePassword,
-            auth_switched: false,
             disconnected: false,
             server_key: None,
             infile_handler: None,
@@ -546,11 +580,11 @@ impl Conn {
                 handshake.mariadb_ext_capabilities() & self.inner.opts.get_mariadb_capabilities();
         }
 
-        // Allow only CachingSha2Password and MysqlNativePassword here
-        // because sha256_password is deprecated and other plugins won't
-        // appear here.
+        // Only plugins that MySQL may advertise in the initial handshake are
+        // accepted here. Other supported plugins are negotiated by auth switch.
         self.inner.auth_plugin = match handshake.auth_plugin() {
             Some(AuthPlugin::CachingSha2Password) => AuthPlugin::CachingSha2Password,
+            Some(AuthPlugin::Sha256Password) => AuthPlugin::Sha256Password,
             _ => AuthPlugin::MysqlNativePassword,
         };
 
@@ -598,14 +632,47 @@ impl Conn {
         }
     }
 
-    async fn do_handshake_response(&mut self) -> Result<()> {
-        let auth_data = self
-            .inner
-            .auth_plugin
-            .gen_data(self.inner.opts.pass(), &self.inner.nonce);
+    fn auth_context(&self) -> AuthContext {
+        AuthContext {
+            pass: self
+                .inner
+                .opts
+                .pass()
+                .map(str::as_bytes)
+                .unwrap_or_default()
+                .to_vec(),
+            is_ipc_transport: self.is_socket(),
+            is_tls_transport: self.is_secure(),
+            scramble: self.inner.nonce.clone(),
+            server_key_pem: self.inner.server_key.clone(),
+        }
+    }
+
+    fn start_auth(&self, plugin: &AuthPlugin<'_>, challenge: &[u8]) -> Result<AuthState> {
+        if matches!(plugin, AuthPlugin::MysqlOldPassword) && self.inner.opts.secure_auth() {
+            return Err(DriverError::MysqlOldPasswordDisabled.into());
+        }
+        if matches!(plugin, AuthPlugin::MysqlClearPassword)
+            && !self.inner.opts.enable_cleartext_plugin()
+        {
+            return Err(DriverError::CleartextPluginDisabled.into());
+        }
+
+        let context = self.auth_context();
+        let mut procedure = plugin.init().map_err(DriverError::from)?;
+        let response = procedure
+            .run(&context, challenge)
+            .map_err(DriverError::from)?;
+        Ok((context, procedure, response))
+    }
+
+    async fn do_handshake_response(&mut self) -> Result<AuthState> {
+        let plugin = self.inner.auth_plugin.clone();
+        let nonce = self.inner.nonce.clone();
+        let state = self.start_auth(&plugin, &nonce)?;
 
         let handshake_response = HandshakeResponse::new(
-            auth_data.as_deref(),
+            state.2.data(),
             self.inner.version,
             self.inner.opts.user().map(|x| x.as_bytes()),
             self.inner.opts.db_name().map(|x| x.as_bytes()),
@@ -619,109 +686,84 @@ impl Conn {
         )
         .with_mariadb_ext_capabilities(self.inner.mariadb_capabilities);
 
-        // Serialize here to satisfy borrow checker.
         let mut buf = crate::buffer_pool().get();
         handshake_response.serialize(buf.as_mut());
 
         self.write_packet(buf).await?;
         self.inner.handshake_complete = true;
-        Ok(())
+        Ok(state)
     }
 
     async fn perform_auth_switch(
         &mut self,
         auth_switch_request: AuthSwitchRequest<'_>,
-    ) -> Result<()> {
-        if !self.inner.auth_switched {
-            self.inner.auth_switched = true;
-            self.inner.nonce = auth_switch_request.plugin_data().to_vec();
+    ) -> Result<AuthState> {
+        self.inner.nonce = auth_switch_request.plugin_data().to_vec();
+        self.inner.auth_plugin = auth_switch_request.auth_plugin().clone().into_owned();
 
-            if matches!(
-                auth_switch_request.auth_plugin(),
-                AuthPlugin::MysqlOldPassword
-            ) && self.inner.opts.secure_auth()
-            {
-                return Err(DriverError::MysqlOldPasswordDisabled.into());
-            }
-
-            self.inner.auth_plugin = auth_switch_request.auth_plugin().clone().into_owned();
-
-            let plugin_data = match &self.inner.auth_plugin {
-                x @ AuthPlugin::CachingSha2Password => {
-                    x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                }
-                x @ AuthPlugin::MysqlNativePassword => {
-                    x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                }
-                x @ AuthPlugin::MysqlOldPassword => {
-                    if self.inner.opts.secure_auth() {
-                        return Err(DriverError::MysqlOldPasswordDisabled.into());
-                    } else {
-                        x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                    }
-                }
-                x @ AuthPlugin::MysqlClearPassword => {
-                    if self.inner.opts.enable_cleartext_plugin() {
-                        x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                    } else {
-                        return Err(DriverError::CleartextPluginDisabled.into());
-                    }
-                }
-                x @ AuthPlugin::Ed25519 => x.gen_data(self.inner.opts.pass(), &self.inner.nonce),
-                // For parsec at this point we need to send an empty packet first
-                _x @ AuthPlugin::MariadbParsec { .. } => None,
-                x @ AuthPlugin::Other(_) => x.gen_data(self.inner.opts.pass(), &self.inner.nonce),
-            };
-
-            if let Some(plugin_data) = plugin_data {
-                self.write_struct(&plugin_data.into_owned()).await?;
-            } else {
-                self.write_packet(crate::buffer_pool().get()).await?;
-            }
-
-            self.continue_auth().await?;
-
-            Ok(())
-        } else {
-            unreachable!("auth_switched flag should be checked by caller")
+        let plugin = self.inner.auth_plugin.clone();
+        let nonce = self.inner.nonce.clone();
+        let state = self.start_auth(&plugin, &nonce)?;
+        if let Some(data) = state.2.data() {
+            self.write_bytes(data).await?;
         }
+        Ok(state)
     }
 
-    fn continue_auth(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
-        // NOTE: we need to box this since it may recurse
-        // see https://github.com/rust-lang/rust/issues/46415#issuecomment-528099782
-        Box::pin(async move {
-            match self.inner.auth_plugin {
-                AuthPlugin::MysqlNativePassword | AuthPlugin::MysqlOldPassword => {
-                    self.continue_mysql_native_password_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::CachingSha2Password => {
-                    self.continue_caching_sha2_password_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::MysqlClearPassword => {
-                    if self.inner.opts.enable_cleartext_plugin() {
-                        self.continue_mysql_native_password_auth().await?;
-                        Ok(())
-                    } else {
-                        Err(DriverError::CleartextPluginDisabled.into())
-                    }
-                }
-                AuthPlugin::Ed25519 => {
-                    self.continue_ed25519_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::MariadbParsec { .. } => {
-                    self.continue_parsec_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::Other(ref name) => Err(DriverError::UnknownAuthPlugin {
-                    name: String::from_utf8_lossy(name.as_ref()).to_string(),
-                }
-                .into()),
+    async fn continue_auth(
+        &mut self,
+        mut auth_switched: bool,
+        mut context: AuthContext,
+        mut procedure: auth::plugins::AuthProc,
+        mut previous_response: auth::plugins::Response,
+    ) -> Result<()> {
+        loop {
+            let packet = self.read_packet().await?;
+
+            if packet.first() == Some(&0xfe) && !auth_switched {
+                let auth_switch = if packet.len() > 1 {
+                    ParseBuf(&packet)
+                        .parse::<AuthSwitchRequest>(())?
+                        .into_owned()
+                } else {
+                    let _ = ParseBuf(&packet).parse::<OldAuthSwitchRequest>(())?;
+                    AuthSwitchRequest::new(
+                        "mysql_old_password".as_bytes(),
+                        self.inner.nonce.clone(),
+                    )
+                };
+                (context, procedure, previous_response) =
+                    self.perform_auth_switch(auth_switch).await?;
+                auth_switched = true;
+                continue;
             }
-        })
+
+            let challenge = packet.strip_prefix(b"\x01").unwrap_or(&packet);
+            if challenge.starts_with(b"-----BEGIN PUBLIC KEY-----") {
+                self.inner.server_key = Some(challenge.to_vec());
+            }
+
+            match previous_response {
+                auth::plugins::Response::Next { .. } => {
+                    let response = procedure
+                        .run(&context, challenge)
+                        .map_err(DriverError::from)?;
+                    if let Some(data) = response.data() {
+                        self.write_bytes(data).await?;
+                    }
+                    previous_response = response;
+                }
+                auth::plugins::Response::Last { .. } => {
+                    if packet.first() == Some(&0x00) {
+                        return Ok(());
+                    }
+                    return Err(DriverError::UnexpectedPacket {
+                        payload: packet.to_vec(),
+                    }
+                    .into());
+                }
+            }
+        }
     }
 
     fn switch_to_compression(&mut self) -> Result<()> {
@@ -733,141 +775,6 @@ impl Conn {
             }
         }
         Ok(())
-    }
-
-    async fn continue_ed25519_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        match packet.first() {
-            Some(0x00) => {
-                // ok packet for empty password
-                Ok(())
-            }
-            Some(0xfe) if !self.inner.auth_switched => {
-                let auth_switch_request = ParseBuf(&packet).parse::<AuthSwitchRequest>(())?;
-                self.perform_auth_switch(auth_switch_request).await
-            }
-            _ => Err(DriverError::UnexpectedPacket {
-                payload: packet.to_vec(),
-            }
-            .into()),
-        }
-    }
-
-    async fn continue_parsec_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        // Normally we need to skip escaping 0x01 byte. But in first parsec implementations, server did not send it.
-        let mut payload: &[u8] = &packet;
-        if packet.first() == Some(&0x01) {
-            payload = &packet[1..];
-        }
-        // At this point in future, when it will be possible for parsec to be default authentication method,
-        // we can have authentication switch request. The other possible option here(and for now the only option) -
-        // ext-salt packet.
-        if payload.first() == Some(&0xfe) {
-            let auth_switch_request = ParseBuf(payload).parse(())?;
-            self.perform_auth_switch(auth_switch_request).await
-        } else {
-            // Letting parser function decide if all is fine with the packet
-            self.inner
-                .auth_plugin
-                .read_add_data(payload)
-                .ok_or_else(|| DriverError::InvalidParsecSalt)?;
-            // Now generating response.
-            let plugin_data = self
-                .inner
-                .auth_plugin
-                .gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                .unwrap();
-
-            self.write_struct(&plugin_data.into_owned()).await?;
-            // After client response, server will send either ok or error.
-            let payload = self.read_packet().await?;
-            match payload.first() {
-                Some(0x00) => Ok(()),
-                _ => Err(DriverError::UnexpectedPacket {
-                    payload: payload.to_vec(),
-                }
-                .into()),
-            }
-        }
-    }
-
-    async fn continue_caching_sha2_password_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        match packet.first() {
-            Some(0x00) => {
-                // ok packet for empty password
-                Ok(())
-            }
-            Some(0x01) => match packet.get(1) {
-                Some(0x03) => {
-                    // auth ok
-                    self.drop_packet().await
-                }
-                Some(0x04) => {
-                    let pass = self.inner.opts.pass().unwrap_or_default();
-                    let mut pass = crate::buffer_pool().get_with(pass.as_bytes());
-                    pass.as_mut().push(0);
-
-                    if self.is_secure() || self.is_socket() {
-                        self.write_packet(pass).await?;
-                    } else {
-                        if self.inner.server_key.is_none() {
-                            self.write_bytes(&[0x02][..]).await?;
-                            let packet = self.read_packet().await?;
-                            self.inner.server_key = Some(packet[1..].to_vec());
-                        }
-                        for (i, byte) in pass.as_mut().iter_mut().enumerate() {
-                            *byte ^= self.inner.nonce[i % self.inner.nonce.len()];
-                        }
-                        let encrypted_pass = crypto::encrypt(
-                            &pass,
-                            self.inner.server_key.as_deref().expect("unreachable"),
-                        );
-                        self.write_bytes(&encrypted_pass).await?;
-                    };
-                    self.drop_packet().await?;
-                    Ok(())
-                }
-                _ => Err(DriverError::UnexpectedPacket {
-                    payload: packet.to_vec(),
-                }
-                .into()),
-            },
-            Some(0xfe) if !self.inner.auth_switched => {
-                let auth_switch_request = ParseBuf(&packet).parse::<AuthSwitchRequest>(())?;
-                self.perform_auth_switch(auth_switch_request).await?;
-                Ok(())
-            }
-            _ => Err(DriverError::UnexpectedPacket {
-                payload: packet.to_vec(),
-            }
-            .into()),
-        }
-    }
-
-    async fn continue_mysql_native_password_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        match packet.first() {
-            Some(0x00) => Ok(()),
-            Some(0xfe) if !self.inner.auth_switched => {
-                let auth_switch = if packet.len() > 1 {
-                    ParseBuf(&packet).parse(())?
-                } else {
-                    let _ = ParseBuf(&packet).parse::<OldAuthSwitchRequest>(())?;
-                    // map OldAuthSwitch to AuthSwitch with mysql_old_password plugin
-                    AuthSwitchRequest::new(
-                        "mysql_old_password".as_bytes(),
-                        self.inner.nonce.clone(),
-                    )
-                };
-                self.perform_auth_switch(auth_switch).await
-            }
-            _ => Err(DriverError::UnexpectedPacket {
-                payload: packet.to_vec(),
-            }
-            .into()),
-        }
     }
 
     /// Returns `true` for ProgressReport packet.
@@ -991,11 +898,6 @@ impl Conn {
         self.write_command_raw(buf).await
     }
 
-    async fn drop_packet(&mut self) -> Result<()> {
-        self.read_packet().await?;
-        Ok(())
-    }
-
     async fn run_init_commands(&mut self) -> Result<()> {
         if let Some(callback) = self.inner.opts.after_connect() {
             callback(self).await?;
@@ -1042,8 +944,9 @@ impl Conn {
             conn.setup_stream()?;
             conn.handle_handshake().await?;
             conn.switch_to_ssl_if_needed().await?;
-            conn.do_handshake_response().await?;
-            conn.continue_auth().await?;
+            let (context, procedure, response) = conn.do_handshake_response().await?;
+            conn.continue_auth(false, context, procedure, response)
+                .await?;
             conn.switch_to_compression()?;
             conn.read_settings().await?;
             conn.reconnect_via_socket_if_needed().await?;
@@ -1687,7 +1590,7 @@ mod test {
         type CreateUserFn = fn(bool, (u16, u16, u16), &str) -> Vec<String>;
 
         #[allow(clippy::type_complexity)]
-        const TEST_MATRIX: [(&str, ShouldRunFn, CreateUserFn); 5] = [
+        const TEST_MATRIX: [(&str, ShouldRunFn, CreateUserFn); 6] = [
             (
                 "mysql_old_password",
                 |is_mariadb, version| is_mariadb || version < (5, 7, 0),
@@ -1742,6 +1645,15 @@ mod test {
                     vec![
                         format!("CREATE USER '__mats'@'%' IDENTIFIED WITH caching_sha2_password BY '{pass}'")
                     ]
+                },
+            ),
+            (
+                "sha256_password",
+                |is_mariadb, version| !is_mariadb && version >= (5, 7, 0) && version < (8, 4, 0),
+                |_is_mariadb, _version, pass| {
+                    vec![format!(
+                        "CREATE USER '__mats'@'%' IDENTIFIED WITH sha256_password BY '{pass}'"
+                    )]
                 },
             ),
             (

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -698,12 +698,10 @@ impl Conn {
         &mut self,
         auth_switch_request: AuthSwitchRequest<'_>,
     ) -> Result<AuthState> {
-        self.inner.nonce = auth_switch_request.plugin_data().to_vec();
-        self.inner.auth_plugin = auth_switch_request.auth_plugin().clone().into_owned();
-
-        let plugin = self.inner.auth_plugin.clone();
-        let nonce = self.inner.nonce.clone();
-        let state = self.start_auth(&plugin, &nonce)?;
+        let state = self.start_auth(
+            &auth_switch_request.auth_plugin(),
+            auth_switch_request.plugin_data(),
+        )?;
         if let Some(data) = state.2.data() {
             self.write_bytes(data).await?;
         }

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -715,6 +715,8 @@ impl Conn {
         mut procedure: auth::plugins::AuthProc,
         mut previous_response: auth::plugins::Response,
     ) -> Result<()> {
+        use auth::plugins::{AuthProc, Response};
+
         loop {
             let packet = self.read_packet().await?;
 
@@ -737,12 +739,20 @@ impl Conn {
             }
 
             let challenge = packet.strip_prefix(b"\x01").unwrap_or(&packet);
-            if challenge.starts_with(b"-----BEGIN PUBLIC KEY-----") {
+
+            // cache server key if needed
+            if self.inner.server_key.is_none()
+                && ((matches!(procedure, AuthProc::CachingSha2Password(_))
+                    && previous_response.data() == Some(&[0x02]))
+                    || (matches!(procedure, AuthProc::Sha256Password(_))
+                        && previous_response.data() == Some(&[0x01])))
+                && challenge.starts_with(b"-----BEGIN")
+            {
                 self.inner.server_key = Some(challenge.to_vec());
             }
 
             match previous_response {
-                auth::plugins::Response::Next { .. } => {
+                Response::Next { .. } => {
                     let response = procedure
                         .run(&context, challenge)
                         .map_err(DriverError::from)?;
@@ -751,7 +761,7 @@ impl Conn {
                     }
                     previous_response = response;
                 }
-                auth::plugins::Response::Last { .. } => {
+                Response::Last { .. } => {
                     if packet.first() == Some(&0x00) {
                         return Ok(());
                     }

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1719,43 +1719,76 @@ mod test {
             let version = conn.server_version();
 
             if should_run(is_mariadb, version) {
-                let pass = random_pass();
+                for pass in [String::new(), random_pass()] {
+                    let result = conn
+                        .query_drop(
+                            "DROP USER /*!50700 IF EXISTS */ /*M!100103 IF EXISTS */ __mats",
+                        )
+                        .await;
 
-                let result = conn
-                    .query_drop("DROP USER /*!50700 IF EXISTS */ /*M!100103 IF EXISTS */ __mats")
-                    .await;
+                    if matches!(version, (5, 6, _)) && i == 0 {
+                        // IF EXISTS is not supported on 5.6 so the query will fail on the first iteration
+                        drop(result);
+                    } else {
+                        result.unwrap();
+                    }
 
-                if matches!(version, (5, 6, _)) && i == 0 {
-                    // IF EXISTS is not supported on 5.6 so the query will fail on the first iteration
-                    drop(result);
-                } else {
-                    result.unwrap();
-                }
+                    for statement in create_statements(is_mariadb, version, &pass) {
+                        conn.query_drop(dbg!(statement)).await.unwrap();
+                    }
 
-                for statement in create_statements(is_mariadb, version, &pass) {
-                    conn.query_drop(dbg!(statement)).await.unwrap();
-                }
-
-                let mut conn2 = Conn::new(get_opts().secure_auth(false)).await.unwrap();
-                conn2
-                    .change_user(
-                        ChangeUserOpts::default()
-                            .with_db_name(None)
-                            .with_user(Some("__mats".into()))
-                            .with_pass(Some(pass)),
+                    let mut conn3 = Conn::new(
+                        get_opts()
+                            .secure_auth(false)
+                            .user(Some("__mats"))
+                            .pass(if pass.is_empty() {
+                                None
+                            } else {
+                                Some(pass.clone())
+                            })
+                            .db_name(None::<String>)
+                            .max_allowed_packet(Some(1024 * 1024 * 4))
+                            .prefer_socket(false)
+                            .init(Vec::<String>::new()),
                     )
                     .await
                     .unwrap();
 
-                let (db, user) = conn2
-                    .query_first::<(Option<String>, String), _>("SELECT DATABASE(), USER();")
-                    .await
-                    .unwrap()
-                    .unwrap();
-                assert_eq!(db, None);
-                assert!(user.starts_with("__mats"));
+                    let (db, user) = conn3
+                        .query_first::<(Option<String>, String), _>("SELECT DATABASE(), USER();")
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(db, None);
+                    assert!(user.starts_with("__mats"));
 
-                conn2.disconnect().await.unwrap();
+                    conn3.disconnect().await.unwrap();
+
+                    let mut conn2 = Conn::new(get_opts().secure_auth(false)).await.unwrap();
+                    conn2
+                        .change_user(
+                            ChangeUserOpts::default()
+                                .with_db_name(None)
+                                .with_user(Some("__mats".into()))
+                                .with_pass(if pass.is_empty() {
+                                    None
+                                } else {
+                                    Some(pass.clone())
+                                }),
+                        )
+                        .await
+                        .unwrap();
+
+                    let (db, user) = conn2
+                        .query_first::<(Option<String>, String), _>("SELECT DATABASE(), USER();")
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(db, None);
+                    assert!(user.starts_with("__mats"));
+
+                    conn2.disconnect().await.unwrap();
+                }
             }
         }
 

--- a/src/conn/routines/change_user.rs
+++ b/src/conn/routines/change_user.rs
@@ -29,7 +29,7 @@ impl Routine<()> for ChangeUser {
         let fut = async move {
             let plugin = conn.inner.auth_plugin.clone();
             let nonce = conn.inner.nonce.clone();
-            let (context, procedure, response) = conn.start_auth(&plugin, &nonce)?;
+            let (context, procedure, response) = conn.start_auth(&plugin, &nonce).await?;
 
             let com_change_user = ComChangeUser::new()
                 .with_user(conn.opts().user().map(|x| x.as_bytes()))

--- a/src/conn/routines/change_user.rs
+++ b/src/conn/routines/change_user.rs
@@ -26,30 +26,29 @@ impl Routine<()> for ChangeUser {
             mysql_async.connection.id = conn.id()
         );
 
-        let com_change_user = ComChangeUser::new()
-            .with_user(conn.opts().user().map(|x| x.as_bytes()))
-            .with_database(conn.opts().db_name().map(|x| x.as_bytes()))
-            .with_auth_plugin_data(
-                conn.inner
-                    .auth_plugin
-                    .gen_data(conn.opts().pass(), &conn.inner.nonce)
-                    .as_deref(),
-            )
-            .with_more_data(Some(
-                ComChangeUserMoreData::new(if conn.inner.version >= (5, 5, 3) {
-                    UTF8MB4_GENERAL_CI
-                } else {
-                    UTF8_GENERAL_CI
-                })
-                .with_auth_plugin(Some(conn.inner.auth_plugin.clone()))
-                .with_connect_attributes(conn.opts().connect_attributes().cloned()),
-            ))
-            .into_owned();
-
         let fut = async move {
+            let plugin = conn.inner.auth_plugin.clone();
+            let nonce = conn.inner.nonce.clone();
+            let (context, procedure, response) = conn.start_auth(&plugin, &nonce)?;
+
+            let com_change_user = ComChangeUser::new()
+                .with_user(conn.opts().user().map(|x| x.as_bytes()))
+                .with_database(conn.opts().db_name().map(|x| x.as_bytes()))
+                .with_auth_plugin_data(response.data())
+                .with_more_data(Some(
+                    ComChangeUserMoreData::new(if conn.inner.version >= (5, 5, 3) {
+                        UTF8MB4_GENERAL_CI
+                    } else {
+                        UTF8_GENERAL_CI
+                    })
+                    .with_auth_plugin(Some(conn.inner.auth_plugin.clone()))
+                    .with_connect_attributes(conn.opts().connect_attributes().cloned()),
+                ))
+                .into_owned();
+
             conn.write_command(&com_change_user).await?;
-            conn.inner.auth_switched = false;
-            conn.continue_auth().await?;
+            conn.continue_auth(false, context, procedure, response)
+                .await?;
             Ok(())
         };
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,6 +11,7 @@ pub use url::ParseError;
 pub mod tls;
 
 use mysql_common::{
+    auth::plugins::{self, PluginInitError},
     named_params::MixedParamsError,
     packets::{BulkExecuteRequestBuilderError, BulkExecuteRequestError},
     params::{MissingNamedParameterError, ParamsError},
@@ -181,8 +182,27 @@ pub enum DriverError {
     #[error("Invalid parsec ext-salt packet received from server")]
     InvalidParsecSalt,
 
+    #[error("Authentication plugin error: {}", _0)]
+    AuthPlugin(#[source] plugins::Error),
+
     #[error("Bulk execute error: {}", _0)]
     BulkExecute(BulkExecuteRequestError),
+}
+
+impl From<PluginInitError> for DriverError {
+    fn from(value: PluginInitError) -> Self {
+        match value {
+            PluginInitError::UnsupportedPlugin(name) => Self::UnknownAuthPlugin {
+                name: String::from_utf8_lossy(&name).into_owned(),
+            },
+        }
+    }
+}
+
+impl From<plugins::Error> for DriverError {
+    fn from(value: plugins::Error) -> Self {
+        Self::AuthPlugin(value)
+    }
 }
 
 impl From<BulkExecuteRequestBuilderError> for DriverError {

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -711,6 +711,12 @@ pub(crate) struct MysqlOpts {
     /// It makes MySQL return the FOUND rows instead of the AFFECTED rows.
     client_found_rows: bool,
 
+    /// Enables `CLIENT_DEPRECATE_EOF` capability (defaults to `true`).
+    ///
+    /// This can be disabled for compatibility with proxies that advertise the capability but
+    /// still send legacy EOF packets.
+    deprecate_eof: bool,
+
     /// Enables Client-Side Cleartext Pluggable Authentication (defaults to `false`).
     ///
     /// Enables client to send passwords to the server as cleartext, without hashing or encryption
@@ -1147,6 +1153,11 @@ impl Opts {
         self.inner.mysql_opts.client_found_rows
     }
 
+    /// Returns `true` if `CLIENT_DEPRECATE_EOF` capability is enabled (defaults to `true`).
+    pub fn deprecate_eof(&self) -> bool {
+        self.inner.mysql_opts.deprecate_eof
+    }
+
     /// Returns `true` if `mysql_clear_password` plugin support is enabled (defaults to `false`).
     ///
     /// `mysql_clear_password` enables client to send passwords to the server as cleartext, without
@@ -1186,9 +1197,11 @@ impl Opts {
             | CapabilityFlags::CLIENT_MULTI_STATEMENTS
             | CapabilityFlags::CLIENT_MULTI_RESULTS
             | CapabilityFlags::CLIENT_PS_MULTI_RESULTS
-            | CapabilityFlags::CLIENT_DEPRECATE_EOF
             | CapabilityFlags::CLIENT_PLUGIN_AUTH;
 
+        if self.deprecate_eof() {
+            out |= CapabilityFlags::CLIENT_DEPRECATE_EOF;
+        }
         if self.inner.mysql_opts.db_name.is_some() {
             out |= CapabilityFlags::CLIENT_CONNECT_WITH_DB;
         }
@@ -1239,6 +1252,7 @@ impl Default for MysqlOpts {
             wait_timeout: None,
             secure_auth: true,
             client_found_rows: false,
+            deprecate_eof: true,
             enable_cleartext_plugin: false,
             connect_attributes: None,
         }
@@ -1561,6 +1575,12 @@ impl OptsBuilder {
     /// Enables or disables `CLIENT_FOUND_ROWS` capability. See [`Opts::client_found_rows`].
     pub fn client_found_rows(mut self, client_found_rows: bool) -> Self {
         self.opts.client_found_rows = client_found_rows;
+        self
+    }
+
+    /// Enables or disables `CLIENT_DEPRECATE_EOF` capability. See [`Opts::deprecate_eof`].
+    pub fn deprecate_eof(mut self, deprecate_eof: bool) -> Self {
+        self.opts.deprecate_eof = deprecate_eof;
         self
     }
 
@@ -2141,7 +2161,7 @@ impl TryFrom<&str> for Opts {
 #[cfg(test)]
 mod test {
     use super::{HostPortOrUrl, MysqlOpts, Opts, Url};
-    use crate::{error::UrlError::InvalidParamValue, SslOpts};
+    use crate::{consts::CapabilityFlags, error::UrlError::InvalidParamValue, SslOpts};
 
     use std::{net::IpAddr, net::Ipv4Addr, net::Ipv6Addr, str::FromStr};
 
@@ -2186,6 +2206,21 @@ mod test {
             url_opts.hostport_or_url().get_tcp_port(),
             builder_opts.hostport_or_url().get_tcp_port()
         );
+    }
+
+    #[test]
+    fn deprecate_eof_capability_can_be_disabled() {
+        let default_opts = Opts::default();
+        assert!(default_opts.deprecate_eof());
+        assert!(default_opts
+            .get_capabilities()
+            .contains(CapabilityFlags::CLIENT_DEPRECATE_EOF));
+
+        let legacy_eof_opts = Opts::from(super::OptsBuilder::default().deprecate_eof(false));
+        assert!(!legacy_eof_opts.deprecate_eof());
+        assert!(!legacy_eof_opts
+            .get_capabilities()
+            .contains(CapabilityFlags::CLIENT_DEPRECATE_EOF));
     }
 
     #[test]

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -715,6 +715,8 @@ pub(crate) struct MysqlOpts {
     ///
     /// This can be disabled for compatibility with proxies that advertise the capability but
     /// still send legacy EOF packets.
+    ///
+    /// Available via `deprecate_eof` connection url parameter.
     deprecate_eof: bool,
 
     /// Enables Client-Side Cleartext Pluggable Authentication (defaults to `false`).
@@ -1154,6 +1156,18 @@ impl Opts {
     }
 
     /// Returns `true` if `CLIENT_DEPRECATE_EOF` capability is enabled (defaults to `true`).
+    ///
+    /// # Connection URL
+    ///
+    /// Use `deprecate_eof` URL parameter to set this value. E.g.
+    ///
+    /// ```
+    /// # use mysql_async::*;
+    /// # fn main() -> Result<()> {
+    /// let opts = Opts::from_url("mysql://localhost/db?deprecate_eof=false")?;
+    /// assert!(!opts.deprecate_eof());
+    /// # Ok(()) }
+    /// ```
     pub fn deprecate_eof(&self) -> bool {
         self.inner.mysql_opts.deprecate_eof
     }
@@ -2023,6 +2037,18 @@ fn mysql_opts_from_url(url: &Url) -> std::result::Result<MysqlOpts, UrlError> {
                 _ => {
                     return Err(UrlError::InvalidParamValue {
                         param: "client_found_rows".into(),
+                        value,
+                    });
+                }
+            }
+        } else if key == "deprecate_eof" {
+            match bool::from_str(&value) {
+                Ok(deprecate_eof) => {
+                    opts.deprecate_eof = deprecate_eof;
+                }
+                _ => {
+                    return Err(UrlError::InvalidParamValue {
+                        param: "deprecate_eof".into(),
                         value,
                     });
                 }

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -142,10 +142,19 @@ impl HostPortOrUrl {
 }
 
 /// Represents data that is either on-disk or in the buffer.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PathOrBuf<'a> {
     Path(Cow<'a, Path>),
     Buf(Cow<'a, [u8]>),
+}
+
+impl<'a> fmt::Debug for PathOrBuf<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path(arg0) => f.debug_tuple("Path").field(arg0).finish(),
+            Self::Buf(_arg0) => f.debug_tuple("Buf").field(&"<REDACTED>").finish(),
+        }
+    }
 }
 
 impl<'a> PathOrBuf<'a> {
@@ -614,7 +623,7 @@ impl fmt::Debug for AfterConnectCallbackWrapper {
 /// Mysql connection options.
 ///
 /// Build one with [`OptsBuilder`].
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq)]
 pub(crate) struct MysqlOpts {
     /// User (defaults to `None`).
     user: Option<String>,
@@ -719,6 +728,17 @@ pub(crate) struct MysqlOpts {
     /// Available via `deprecate_eof` connection url parameter.
     deprecate_eof: bool,
 
+    /// Returns server public key path (defaults to `None`).
+    ///
+    /// The path contains a client side copy of the server public key in PEM format.
+    ///
+    /// # Security Notes
+    ///
+    /// This is not a TLS option — this path is used only for caching_sha2_password plugin
+    /// to make it not vulnerable to MITM. If it is not given then the public key will be
+    /// requested from the server.
+    server_key_path: Option<PathBuf>,
+
     /// Enables Client-Side Cleartext Pluggable Authentication (defaults to `false`).
     ///
     /// Enables client to send passwords to the server as cleartext, without hashing or encryption
@@ -735,6 +755,37 @@ pub(crate) struct MysqlOpts {
     /// When set, the client will advertise `CLIENT_CONNECT_ATTRS` and send the provided
     /// key-value attributes to the server.
     connect_attributes: Option<std::collections::HashMap<String, String>>,
+}
+
+impl fmt::Debug for MysqlOpts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MysqlOpts")
+            .field("user", &self.user)
+            .field("pass", &"<REDACTED>")
+            .field("db_name", &self.db_name)
+            .field("tcp_keepalive", &self.tcp_keepalive)
+            .field("tcp_nodelay", &self.tcp_nodelay)
+            .field("local_infile_handler", &self.local_infile_handler)
+            .field("pool_opts", &self.pool_opts)
+            .field("conn_ttl", &self.conn_ttl)
+            .field("after_connect", &self.after_connect)
+            .field("init", &self.init)
+            .field("setup", &self.setup)
+            .field("stmt_cache_size", &self.stmt_cache_size)
+            .field("ssl_opts", &self.ssl_opts)
+            .field("prefer_socket", &self.prefer_socket)
+            .field("socket", &self.socket)
+            .field("compression", &self.compression)
+            .field("max_allowed_packet", &self.max_allowed_packet)
+            .field("wait_timeout", &self.wait_timeout)
+            .field("secure_auth", &self.secure_auth)
+            .field("client_found_rows", &self.client_found_rows)
+            .field("deprecate_eof", &self.deprecate_eof)
+            .field("server_key_path", &self.server_key_path)
+            .field("enable_cleartext_plugin", &self.enable_cleartext_plugin)
+            .field("connect_attributes", &self.connect_attributes)
+            .finish()
+    }
 }
 
 /// Mysql connection options.
@@ -1172,6 +1223,11 @@ impl Opts {
         self.inner.mysql_opts.deprecate_eof
     }
 
+    /// Returns server public key path (defaults to `None`) (see [`OptsBuilder::server_key_path`]).
+    pub fn server_key_path(&self) -> Option<&Path> {
+        self.inner.mysql_opts.server_key_path.as_deref()
+    }
+
     /// Returns `true` if `mysql_clear_password` plugin support is enabled (defaults to `false`).
     ///
     /// `mysql_clear_password` enables client to send passwords to the server as cleartext, without
@@ -1269,6 +1325,7 @@ impl Default for MysqlOpts {
             deprecate_eof: true,
             enable_cleartext_plugin: false,
             connect_attributes: None,
+            server_key_path: None,
         }
     }
 }
@@ -1595,6 +1652,32 @@ impl OptsBuilder {
     /// Enables or disables `CLIENT_DEPRECATE_EOF` capability. See [`Opts::deprecate_eof`].
     pub fn deprecate_eof(mut self, deprecate_eof: bool) -> Self {
         self.opts.deprecate_eof = deprecate_eof;
+        self
+    }
+
+    /// Sets server public key path (defaults to `None`).
+    ///
+    /// The path contains a client side copy of the server public key in PEM format.
+    ///
+    /// # Security Notes
+    ///
+    /// This is not a TLS option — this path is used only for caching_sha2_password plugin
+    /// to make it not vulnerable to MITM. If it is not given then the public key will be
+    /// requested from the server.
+    ///
+    /// # Connection URL
+    ///
+    /// Use `server_key_path` URL parameter to set this value. E.g.
+    ///
+    /// ```
+    /// # use mysql_async::*;
+    /// # use std::path::Path;
+    /// # fn main() -> Result<()> {
+    /// let opts = Opts::from_url("mysql://localhost/db?server_key_path=/some/path/key.pem")?;
+    /// assert_eq!(opts.server_key_path(), Some(Path::new("/some/path/key.pem")));
+    /// # Ok(()) }
+    pub fn server_key_path(mut self, server_key_path: Option<PathBuf>) -> Self {
+        self.opts.server_key_path = server_key_path;
         self
     }
 
@@ -2055,6 +2138,8 @@ fn mysql_opts_from_url(url: &Url) -> std::result::Result<MysqlOpts, UrlError> {
             }
         } else if key == "socket" {
             opts.socket = Some(value)
+        } else if key == "server_key_path" {
+            opts.server_key_path = Some(value.into())
         } else if key == "compression" {
             if value == "fast" {
                 opts.compression = Some(crate::Compression::fast());


### PR DESCRIPTION
Follow-up to blackbeam/rust_mysql_common#186.

This updates `mysql_async` to use the generic authentication state machines introduced by `mysql_common` 0.38 and adds `sha256_password` support without keeping plugin-specific protocol logic in `Conn`.

Changes:

- drives every authentication plugin through `AuthProc` and `ChallengeResponsePlugin::run`;
- handles initial handshake, escaped auth-more-data packets, auth switch, and `COM_CHANGE_USER` through the same loop;
- recognizes `sha256_password` during the initial handshake;
- preserves the existing security checks for `mysql_old_password` and `mysql_clear_password`;
- caches retrieved RSA public keys for subsequent authentication attempts;
- adds `sha256_password` to the change-user authentication test matrix for supported MySQL versions.

The dependency is temporarily pinned to the companion `mysql_common` PR commit. It should be replaced with the released `mysql_common` 0.38 version after blackbeam/rust_mysql_common#186 is merged.

Validation:

- all 16 Azure Pipelines jobs pass, including stable, beta, nightly, Windows, MariaDB 10–12, MySQL 5.6–9.1, and TiDB 5.4–8.5;
- default, minimal, native-tls, and rustls feature configurations compile;
- `COM_CHANGE_USER` passes for `mysql_native_password`, `caching_sha2_password`, and `sha256_password`;
- initial `sha256_password` login was verified against MySQL 8.0.46 over plain TCP with RSA public-key retrieval.
