### PR TITLE
Porting of "Zero config TLS" MariaDB feature support from mysql-simple

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 futures-sink = "0.3"
 keyed_priority_queue = "0.4"
 lru = "0.18"
-mysql_common = { version = "0.37.1", default-features = false }
+mysql_common = { version = "0.38.0", default-features = false }
 pem = { version = "3.0", optional = true }
 percent-encoding = "2.1.0"
 rand = "0.10"
@@ -64,6 +64,14 @@ default-features = false
 features = ["std"]
 optional = true
 
+[dependencies.sha2]
+version = "0.10.0"
+optional = true
+
+[dependencies.x509-parser]
+version = "0.18"
+optional = true
+
 [dependencies.webpki-roots]
 version = "1"
 optional = true
@@ -97,7 +105,7 @@ minimal-rust = ["flate2/rust_backend"]
 native-tls-tls = ["native-tls", "tokio-native-tls", "pem"]
 
 # rustls based TLS support
-rustls-tls = ["rustls", "tokio-rustls", "webpki-roots"]
+rustls-tls = ["rustls", "tokio-rustls", "webpki-roots", "dep:sha2", "dep:x509-parser"]
 
 aws-lc-rs = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs"]
 ring = ["rustls/ring", "tokio-rustls/ring"]

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -9,10 +9,11 @@
 use futures_util::FutureExt;
 
 use mysql_common::{
+    auth::plugins::{AuthProc, ChallengeResponsePlugin, Context as AuthContextTrait, Response},
     constants::{
         MariadbCapabilities, DEFAULT_MAX_ALLOWED_PACKET, UTF8MB4_GENERAL_CI, UTF8_GENERAL_CI,
     },
-    crypto,
+    crypto::MariaDbZeroConfigCheck,
     io::ParseBuf,
     packets::{
         AuthPlugin, AuthSwitchRequest, CommonOkPacket, ErrPacket, HandshakePacket,
@@ -30,7 +31,7 @@ use std::{
     mem::{self, replace},
     pin::Pin,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -116,8 +117,8 @@ struct ConnInner {
     wait_timeout: Duration,
     stmt_cache: StmtCache,
     nonce: Vec<u8>,
+    zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
     auth_plugin: AuthPlugin<'static>,
-    auth_switched: bool,
     server_key: Option<Vec<u8>>,
     active_since: Instant,
     /// Connection is already disconnected.
@@ -170,8 +171,8 @@ impl ConnInner {
             opts,
             ttl_deadline,
             nonce: Vec::default(),
+            zero_config_check: None,
             auth_plugin: AuthPlugin::MysqlNativePassword,
-            auth_switched: false,
             disconnected: false,
             server_key: None,
             infile_handler: None,
@@ -203,6 +204,77 @@ pub struct Conn {
 }
 
 impl Conn {
+    fn auth_context_owned(&self) -> AuthContext {
+        AuthContext {
+            pass: self.inner.opts.pass().unwrap_or_default().to_owned(),
+            is_ipc_transport: self.is_socket(),
+            is_tls_transport: self.is_secure(),
+            scramble: self.inner.nonce.clone(),
+            server_key_pem: self.inner.server_key.clone(),
+        }
+    }
+
+    async fn auth_context(&mut self) -> Result<AuthContext> {
+        let mut server_key_pem = self.inner.server_key.clone();
+
+        // Try to load server_key_pem from file if server_key_path is configured and we don't have it cached
+        if server_key_pem.is_none()
+            || server_key_pem
+                .as_ref()
+                .map(|v| v.is_empty())
+                .unwrap_or_default()
+        {
+            if let Some(server_key_path) = self.inner.opts.get_server_key_path() {
+                match tokio::fs::read(server_key_path).await {
+                    Ok(pem) => {
+                        server_key_pem = Some(pem);
+                        self.inner.server_key = server_key_pem.clone();
+                    }
+                    Err(_) => {
+                        // Ignore file read errors - the server will provide the key
+                    }
+                }
+            }
+        }
+
+        Ok(AuthContext {
+            pass: self.inner.opts.pass().unwrap_or_default().to_owned(),
+            is_ipc_transport: self.is_socket(),
+            is_tls_transport: self.is_secure(),
+            scramble: self.inner.nonce.clone(),
+            server_key_pem,
+        })
+    }
+
+    fn zero_config_fallback_pending(&self) -> bool {
+        self.inner
+            .zero_config_check
+            .as_ref()
+            .and_then(|x| x.lock().ok())
+            .and_then(|guard| {
+                guard
+                    .as_ref()
+                    .map(|check| check.requires_zeroconfig_fallback())
+            })
+            .unwrap_or(false)
+    }
+
+    fn zero_config_leaf_cert_fingerprint(&self) -> Option<Vec<u8>> {
+        self.inner
+            .zero_config_check
+            .as_ref()
+            .and_then(|x| x.lock().ok())
+            .and_then(|guard| {
+                guard.as_ref().and_then(|check| {
+                    if check.requires_zeroconfig_fallback() {
+                        Some(check.leaf_cert_fingerprint().to_vec())
+                    } else {
+                        None
+                    }
+                })
+            })
+    }
+
     /// Returns connection identifier.
     pub fn id(&self) -> u32 {
         self.inner.id
@@ -494,6 +566,19 @@ impl Conn {
         false
     }
 
+    fn mariadb_fallback_possible(&self) -> bool {
+        self.inner.is_mariadb
+            && self.inner.version > (11, 4, 0)
+            && self.inner.opts.pass().is_some_and(|x| !x.is_empty())
+            && self.inner.auth_plugin.supports_password_hash()
+            && self
+                .inner
+                .opts
+                .ssl_opts()
+                .map(|ssl_opts| ssl_opts.root_certs().is_empty())
+                .unwrap_or_default()
+    }
+
     /// Hacky way to move connection through &mut. `self` becomes unusable.
     fn take(&mut self) -> Conn {
         mem::replace(self, Conn::empty(Default::default()))
@@ -582,13 +667,21 @@ impl Conn {
             .with_mariadb_capabilities(self.inner.mariadb_capabilities);
             self.write_struct(&ssl_request).await?;
             let conn = self;
-            let ssl_opts = conn.opts().ssl_opts_and_connector().expect("unreachable");
+            let ssl_opts = conn
+                .opts()
+                .ssl_opts_and_connector()
+                .expect("unreachable")
+                .clone();
+            let zero_config_check = conn
+                .mariadb_fallback_possible()
+                .then(|| Arc::new(Mutex::new(None)));
+            conn.inner.zero_config_check = zero_config_check.clone();
             let domain = ssl_opts
                 .ssl_opts()
                 .tls_hostname_override()
                 .unwrap_or_else(|| conn.opts().ip_or_hostname())
                 .into();
-            let tls_connector = ssl_opts.build_tls_connector().await?;
+            let tls_connector = ssl_opts.build_tls_connector(zero_config_check).await?;
             conn.stream_mut()?
                 .make_secure(domain, &tls_connector)
                 .await?;
@@ -599,13 +692,17 @@ impl Conn {
     }
 
     async fn do_handshake_response(&mut self) -> Result<()> {
-        let auth_data = self
-            .inner
-            .auth_plugin
-            .gen_data(self.inner.opts.pass(), &self.inner.nonce);
+        let auth_context = self.auth_context_owned();
+        let mut auth_proc = self.inner.auth_plugin.init()?;
+        let nonce = self.inner.nonce.clone();
+        #[cfg(test)]
+        eprintln!("{}:{} {auth_proc:?}\n{:?}", file!(), line!(), nonce);
+        let response = auth_proc
+            .run(auth_context.clone(), &nonce)
+            .map_err(Error::from)?;
 
         let handshake_response = HandshakeResponse::new(
-            auth_data.as_deref(),
+            response.data(),
             self.inner.version,
             self.inner.opts.user().map(|x| x.as_bytes()),
             self.inner.opts.db_name().map(|x| x.as_bytes()),
@@ -625,102 +722,112 @@ impl Conn {
 
         self.write_packet(buf).await?;
         self.inner.handshake_complete = true;
+
+        // Handle authentication challenge-response loop
+        self.continue_auth(false, auth_context, auth_proc, response)
+            .await?;
+
         Ok(())
     }
 
     async fn perform_auth_switch(
         &mut self,
         auth_switch_request: AuthSwitchRequest<'_>,
-    ) -> Result<()> {
-        if !self.inner.auth_switched {
-            self.inner.auth_switched = true;
-            self.inner.nonce = auth_switch_request.plugin_data().to_vec();
-
-            if matches!(
-                auth_switch_request.auth_plugin(),
-                AuthPlugin::MysqlOldPassword
-            ) && self.inner.opts.secure_auth()
-            {
-                return Err(DriverError::MysqlOldPasswordDisabled.into());
-            }
-
-            self.inner.auth_plugin = auth_switch_request.auth_plugin().clone().into_owned();
-
-            let plugin_data = match &self.inner.auth_plugin {
-                x @ AuthPlugin::CachingSha2Password => {
-                    x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                }
-                x @ AuthPlugin::MysqlNativePassword => {
-                    x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                }
-                x @ AuthPlugin::MysqlOldPassword => {
-                    if self.inner.opts.secure_auth() {
-                        return Err(DriverError::MysqlOldPasswordDisabled.into());
-                    } else {
-                        x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                    }
-                }
-                x @ AuthPlugin::MysqlClearPassword => {
-                    if self.inner.opts.enable_cleartext_plugin() {
-                        x.gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                    } else {
-                        return Err(DriverError::CleartextPluginDisabled.into());
-                    }
-                }
-                x @ AuthPlugin::Ed25519 => x.gen_data(self.inner.opts.pass(), &self.inner.nonce),
-                // For parsec at this point we need to send an empty packet first
-                _x @ AuthPlugin::MariadbParsec { .. } => None,
-                x @ AuthPlugin::Other(_) => x.gen_data(self.inner.opts.pass(), &self.inner.nonce),
-            };
-
-            if let Some(plugin_data) = plugin_data {
-                self.write_struct(&plugin_data.into_owned()).await?;
-            } else {
-                self.write_packet(crate::buffer_pool().get()).await?;
-            }
-
-            self.continue_auth().await?;
-
-            Ok(())
-        } else {
-            unreachable!("auth_switched flag should be checked by caller")
+    ) -> Result<AuthProc> {
+        // If MariaDb "zero-config TLS" is in progress, then only supported plugins are allowed
+        #[cfg(feature = "rustls")]
+        if self.zero_config_fallback_pending()
+            && !auth_switch_request.auth_plugin().supports_password_hash()
+        {
+            return Err(
+                rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer).into(),
+            );
         }
+
+        let auth_ctx = self.auth_context().await?;
+        let mut auth_proc = auth_switch_request.auth_plugin().init()?;
+        #[cfg(test)]
+        eprintln!(
+            "{}:{} {auth_proc:?}\n{:?}",
+            file!(),
+            line!(),
+            auth_switch_request.plugin_data()
+        );
+        let response = auth_proc.run(auth_ctx.clone(), auth_switch_request.plugin_data())?;
+        if let Some(packet) = response.data() {
+            let buf = crate::buffer_pool().get_with(packet);
+            self.write_packet(buf).await?;
+        }
+
+        self.continue_auth(true, auth_ctx, auth_proc, response)
+            .await
     }
 
-    fn continue_auth(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+    fn continue_auth(
+        &mut self,
+        auth_switched: bool,
+        auth_ctx: AuthContext,
+        mut auth_proc: AuthProc,
+        mut prev_response: Response,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthProc>> + Send + '_>> {
         // NOTE: we need to box this since it may recurse
         // see https://github.com/rust-lang/rust/issues/46415#issuecomment-528099782
         Box::pin(async move {
-            match self.inner.auth_plugin {
-                AuthPlugin::MysqlNativePassword | AuthPlugin::MysqlOldPassword => {
-                    self.continue_mysql_native_password_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::CachingSha2Password => {
-                    self.continue_caching_sha2_password_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::MysqlClearPassword => {
-                    if self.inner.opts.enable_cleartext_plugin() {
-                        self.continue_mysql_native_password_auth().await?;
-                        Ok(())
+            loop {
+                // read next challenge
+                let packet = self.read_packet().await?;
+
+                // check for auth-switch
+                if packet[0] == 0xFE && !auth_switched {
+                    let auth_switch = if packet.len() > 1 {
+                        ParseBuf(&packet).parse(())?
                     } else {
-                        Err(DriverError::CleartextPluginDisabled.into())
+                        let _ = ParseBuf(&packet).parse::<OldAuthSwitchRequest>(())?;
+                        // we'll map OldAuthSwitchRequest to an AuthSwitchRequest with mysql_old_password plugin.
+                        AuthSwitchRequest::new("mysql_old_password".as_bytes(), &*self.inner.nonce)
+                            .into_owned()
+                    };
+                    return self.perform_auth_switch(auth_switch).await;
+                }
+
+                // check for escaping byte
+                let challenge = if packet[0] == 0x01 {
+                    &packet[1..]
+                } else {
+                    packet.as_ref()
+                };
+
+                match prev_response {
+                    // plugin waits for another challenge
+                    Response::Next { .. } => {
+                        #[cfg(test)]
+                        eprintln!("{}:{} {auth_proc:?}\n{:?}", file!(), line!(), challenge);
+                        let response = auth_proc.run(auth_ctx.clone(), challenge)?;
+                        if let Some(packet) = response.data() {
+                            let buf = crate::buffer_pool().get_with(packet);
+                            self.write_packet(buf).await?;
+                        }
+                        prev_response = response;
+                    }
+                    // previous response was the last response for the plugin
+                    // OK packet must follow
+                    Response::Last { .. } => {
+                        if packet[0] == 0x00 {
+                            let ok_packet: OkPacket<'static> = ParseBuf(&packet)
+                                .parse::<OkPacketDeserializer<CommonOkPacket>>(self.capabilities())?
+                                .into_inner()
+                                .into_owned();
+                            self.handle_ok(ok_packet);
+                            break;
+                        } else {
+                            return Err(Error::Other(
+                                "Unexpected packet during authentication".into(),
+                            ));
+                        }
                     }
                 }
-                AuthPlugin::Ed25519 => {
-                    self.continue_ed25519_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::MariadbParsec { .. } => {
-                    self.continue_parsec_auth().await?;
-                    Ok(())
-                }
-                AuthPlugin::Other(ref name) => Err(DriverError::UnknownAuthPlugin {
-                    name: String::from_utf8_lossy(name.as_ref()).to_string(),
-                }
-                .into()),
             }
+            Ok(auth_proc)
         })
     }
 
@@ -733,141 +840,6 @@ impl Conn {
             }
         }
         Ok(())
-    }
-
-    async fn continue_ed25519_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        match packet.first() {
-            Some(0x00) => {
-                // ok packet for empty password
-                Ok(())
-            }
-            Some(0xfe) if !self.inner.auth_switched => {
-                let auth_switch_request = ParseBuf(&packet).parse::<AuthSwitchRequest>(())?;
-                self.perform_auth_switch(auth_switch_request).await
-            }
-            _ => Err(DriverError::UnexpectedPacket {
-                payload: packet.to_vec(),
-            }
-            .into()),
-        }
-    }
-
-    async fn continue_parsec_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        // Normally we need to skip escaping 0x01 byte. But in first parsec implementations, server did not send it.
-        let mut payload: &[u8] = &packet;
-        if packet.first() == Some(&0x01) {
-            payload = &packet[1..];
-        }
-        // At this point in future, when it will be possible for parsec to be default authentication method,
-        // we can have authentication switch request. The other possible option here(and for now the only option) -
-        // ext-salt packet.
-        if payload.first() == Some(&0xfe) {
-            let auth_switch_request = ParseBuf(payload).parse(())?;
-            self.perform_auth_switch(auth_switch_request).await
-        } else {
-            // Letting parser function decide if all is fine with the packet
-            self.inner
-                .auth_plugin
-                .read_add_data(payload)
-                .ok_or_else(|| DriverError::InvalidParsecSalt)?;
-            // Now generating response.
-            let plugin_data = self
-                .inner
-                .auth_plugin
-                .gen_data(self.inner.opts.pass(), &self.inner.nonce)
-                .unwrap();
-
-            self.write_struct(&plugin_data.into_owned()).await?;
-            // After client response, server will send either ok or error.
-            let payload = self.read_packet().await?;
-            match payload.first() {
-                Some(0x00) => Ok(()),
-                _ => Err(DriverError::UnexpectedPacket {
-                    payload: payload.to_vec(),
-                }
-                .into()),
-            }
-        }
-    }
-
-    async fn continue_caching_sha2_password_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        match packet.first() {
-            Some(0x00) => {
-                // ok packet for empty password
-                Ok(())
-            }
-            Some(0x01) => match packet.get(1) {
-                Some(0x03) => {
-                    // auth ok
-                    self.drop_packet().await
-                }
-                Some(0x04) => {
-                    let pass = self.inner.opts.pass().unwrap_or_default();
-                    let mut pass = crate::buffer_pool().get_with(pass.as_bytes());
-                    pass.as_mut().push(0);
-
-                    if self.is_secure() || self.is_socket() {
-                        self.write_packet(pass).await?;
-                    } else {
-                        if self.inner.server_key.is_none() {
-                            self.write_bytes(&[0x02][..]).await?;
-                            let packet = self.read_packet().await?;
-                            self.inner.server_key = Some(packet[1..].to_vec());
-                        }
-                        for (i, byte) in pass.as_mut().iter_mut().enumerate() {
-                            *byte ^= self.inner.nonce[i % self.inner.nonce.len()];
-                        }
-                        let encrypted_pass = crypto::encrypt(
-                            &pass,
-                            self.inner.server_key.as_deref().expect("unreachable"),
-                        );
-                        self.write_bytes(&encrypted_pass).await?;
-                    };
-                    self.drop_packet().await?;
-                    Ok(())
-                }
-                _ => Err(DriverError::UnexpectedPacket {
-                    payload: packet.to_vec(),
-                }
-                .into()),
-            },
-            Some(0xfe) if !self.inner.auth_switched => {
-                let auth_switch_request = ParseBuf(&packet).parse::<AuthSwitchRequest>(())?;
-                self.perform_auth_switch(auth_switch_request).await?;
-                Ok(())
-            }
-            _ => Err(DriverError::UnexpectedPacket {
-                payload: packet.to_vec(),
-            }
-            .into()),
-        }
-    }
-
-    async fn continue_mysql_native_password_auth(&mut self) -> Result<()> {
-        let packet = self.read_packet().await?;
-        match packet.first() {
-            Some(0x00) => Ok(()),
-            Some(0xfe) if !self.inner.auth_switched => {
-                let auth_switch = if packet.len() > 1 {
-                    ParseBuf(&packet).parse(())?
-                } else {
-                    let _ = ParseBuf(&packet).parse::<OldAuthSwitchRequest>(())?;
-                    // map OldAuthSwitch to AuthSwitch with mysql_old_password plugin
-                    AuthSwitchRequest::new(
-                        "mysql_old_password".as_bytes(),
-                        self.inner.nonce.clone(),
-                    )
-                };
-                self.perform_auth_switch(auth_switch).await
-            }
-            _ => Err(DriverError::UnexpectedPacket {
-                payload: packet.to_vec(),
-            }
-            .into()),
-        }
     }
 
     /// Returns `true` for ProgressReport packet.
@@ -1043,7 +1015,6 @@ impl Conn {
             conn.handle_handshake().await?;
             conn.switch_to_ssl_if_needed().await?;
             conn.do_handshake_response().await?;
-            conn.continue_auth().await?;
             conn.switch_to_compression()?;
             conn.read_settings().await?;
             conn.reconnect_via_socket_if_needed().await?;
@@ -1384,6 +1355,37 @@ impl Conn {
     }
 }
 
+#[derive(Clone)]
+struct AuthContext {
+    pass: String,
+    is_ipc_transport: bool,
+    is_tls_transport: bool,
+    scramble: Vec<u8>,
+    server_key_pem: Option<Vec<u8>>,
+}
+
+impl AuthContextTrait for AuthContext {
+    fn pass(&self) -> &[u8] {
+        self.pass.as_bytes()
+    }
+
+    fn is_ipc_transport(&self) -> bool {
+        self.is_ipc_transport
+    }
+
+    fn is_tls_transport(&self) -> bool {
+        self.is_tls_transport
+    }
+
+    fn scramble(&self) -> &[u8] {
+        &self.scramble
+    }
+
+    fn server_key_pem(&self) -> Option<&[u8]> {
+        self.server_key_pem.as_deref()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use bytes::Bytes;
@@ -1399,6 +1401,15 @@ mod test {
         from_row, params, prelude::*, test_misc::get_opts, ChangeUserOpts, Conn, Error,
         OptsBuilder, Pool, ServerError, Value, WhiteListFsHandler,
     };
+
+    fn random_pass() -> String {
+        let mut rng = rand::rng();
+        let pass: [u8; 10] = rng.random();
+
+        IntoIterator::into_iter(pass)
+            .map(|x| ((x % (123 - 97)) + 97) as char)
+            .collect()
+    }
 
     #[tokio::test]
     async fn should_return_found_rows_if_flag_is_set() -> super::Result<()> {
@@ -1763,15 +1774,6 @@ mod test {
                 },
             ),
         ];
-
-        fn random_pass() -> String {
-            let mut rng = rand::rng();
-            let pass: [u8; 10] = rng.random();
-
-            IntoIterator::into_iter(pass)
-                .map(|x| ((x % (123 - 97)) + 97) as char)
-                .collect()
-        }
 
         let mut conn = Conn::new(get_opts()).await?;
 
@@ -2790,6 +2792,168 @@ mod test {
         assert_eq!(fetched_rows[0], 12);
         assert_eq!(fetched_rows2[0], 42);
         assert_eq!(fetched_rows3[0], "foo".to_owned());
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "rustls-tls"))))]
+    #[tokio::test]
+    #[cfg(any(feature = "rustls", feature = "rustls-tls"))]
+    // Test of MariaDB "Zero config SSL" with native authentication - one of three supported by the feature.
+    // First making connection to verify that this is MariaDB server and that it supports "Zero config SSL"
+    // (MariaDB >= 11.4.0) then trying to establish TLS connection making sure that certificate is validated.
+    async fn mariadb_auto_tls() -> crate::Result<()> {
+        let aux = Conn::new(get_opts().ssl_opts(None)).await?;
+        let is_mariadb = aux.inner.is_mariadb;
+        let version = aux.server_version();
+        if is_mariadb && version > (11, 4, 0) {
+            let mut conn = Conn::new(
+                get_opts()
+                    .ssl_opts(crate::SslOpts::default().with_danger_skip_domain_validation(false)),
+            )
+            .await?;
+
+            assert!(conn.is_secure());
+            assert!(conn.ping().await.is_ok());
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            any(feature = "rustls", feature = "rustls-tls"),
+            feature = "client_ed25519"
+        )))
+    )]
+    #[tokio::test]
+    #[cfg(all(
+        any(feature = "rustls", feature = "rustls-tls"),
+        feature = "client_ed25519"
+    ))]
+    // Test of MariaDB "Zero config SSL" with ed25519 authentication
+    async fn mariadb_auto_tls_ed25519() -> crate::Result<()> {
+        let mut aux = Conn::new(get_opts().ssl_opts(None)).await?;
+        let is_mariadb = aux.inner.is_mariadb;
+        let version = aux.server_version();
+        if is_mariadb && version > (11, 4, 0) {
+            let pass = random_pass();
+
+            aux.query_drop("DROP USER IF EXISTS 'ed25519_tls_test_user'@'%'")
+                .await?;
+            let create_user_query = format!(
+                "CREATE USER 'ed25519_tls_test_user'@'%' IDENTIFIED WITH ed25519 USING PASSWORD('{pass}')"
+            );
+            aux.query_drop(create_user_query).await?;
+
+            let mut conn = Conn::new(
+                get_opts()
+                    .user(Some("ed25519_tls_test_user"))
+                    .pass(Some(pass))
+                    .db_name(None::<String>)
+                    .init(vec![] as Vec<String>)
+                    .ssl_opts(crate::SslOpts::default().with_danger_skip_domain_validation(false)),
+            )
+            .await?;
+            assert!(conn.is_secure());
+            assert!(conn.ping().await.is_ok());
+
+            // Testing that we can't make secure connection with empty password.
+            // "Zero config SSL" does not work with empty password.
+            // This can fail if server has real certificate.
+            conn.query_drop("SET PASSWORD = PASSWORD('')").await?;
+            drop(conn);
+
+            let conn = Conn::new(
+                get_opts()
+                    .user(Some("ed25519_tls_test_user"))
+                    .pass(Some(""))
+                    .db_name(None::<String>)
+                    .init(vec![] as Vec<String>)
+                    .ssl_opts(crate::SslOpts::default().with_danger_skip_domain_validation(false)),
+            )
+            .await;
+            // We shouldn't have got secure connection with insecure plugins -
+            // connection should have failed.
+            assert!(conn.is_err());
+            aux.query_drop("DROP USER 'ed25519_tls_test_user'@'%'")
+                .await?;
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            any(feature = "rustls", feature = "rustls-tls"),
+            feature = "client_parsec"
+        )))
+    )]
+    #[tokio::test]
+    #[cfg(all(
+        any(feature = "rustls", feature = "rustls-tls"),
+        feature = "client_parsec"
+    ))]
+    // Test of MariaDB "Zero config SSL" with parsec authentication
+    async fn mariadb_auto_tls_parsec() -> crate::Result<()> {
+        let mut aux = Conn::new(get_opts().ssl_opts(None)).await?;
+        let is_mariadb = aux.inner.is_mariadb;
+        let version = aux.server_version();
+        if is_mariadb && version >= (11, 6, 0) {
+            let pass = random_pass();
+            aux.query_drop("DROP USER IF EXISTS 'parsec_tls_test_user'@'%'")
+                .await?;
+            let create_user_query = format!(
+                "CREATE USER 'parsec_tls_test_user'@'%' IDENTIFIED VIA 'parsec' USING PASSWORD('{pass}')"
+            );
+            aux.query_drop(create_user_query).await?;
+
+            let mut conn = Conn::new(
+                get_opts()
+                    .user(Some("parsec_tls_test_user"))
+                    .pass(Some(pass.clone()))
+                    .db_name(None::<String>)
+                    .init(vec![] as Vec<String>)
+                    .ssl_opts(crate::SslOpts::default().with_danger_skip_domain_validation(false)),
+            )
+            .await?;
+            assert!(conn.is_secure());
+            assert!(conn.ping().await.is_ok());
+            drop(conn);
+            aux.query_drop("DROP USER 'parsec_tls_test_user'@'%'")
+                .await?;
+
+            // caching_sha2_password is not MitM-proof. "Zero config SSL" does not work with such authentication methods.
+            // This can fail if server has real certificate. Combining 2 tests to be sure for the 2nd test that "zero config SSL"
+            // works in general.
+            aux.query_drop("DROP USER IF EXISTS 'caching_sha2_tls_test_user'@'%'")
+                .await?;
+            if aux
+                .query_drop(
+                    "CREATE USER 'caching_sha2_tls_test_user'@'%'
+            IDENTIFIED WITH caching_sha2_password USING PASSWORD('{pass}')",
+                )
+                .await
+                .is_ok()
+            {
+                // Test makes sense only if the plugin is present and active. If we can't create user with such plugin, we can skip the test.
+                let conn = Conn::new(
+                    get_opts()
+                        .user(Some("ed25519_tls_test_user"))
+                        .pass(Some(pass))
+                        .db_name(None::<String>)
+                        .init(vec![] as Vec<String>)
+                        .ssl_opts(
+                            crate::SslOpts::default().with_danger_skip_domain_validation(false),
+                        ),
+                )
+                .await;
+                // We shouldn't have had secure connection with insecure plugins -
+                // connection should have failed.
+                assert!(conn.is_err());
+                aux.query_drop("DROP USER 'caching_sha2_tls_test_user'@'%'")
+                    .await?;
+            }
+        }
+        Ok(())
     }
 
     #[cfg(feature = "nightly")]

--- a/src/conn/routines/change_user.rs
+++ b/src/conn/routines/change_user.rs
@@ -1,6 +1,7 @@
 use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use mysql_common::{
+    auth::plugins::ChallengeResponsePlugin,
     constants::{UTF8MB4_GENERAL_CI, UTF8_GENERAL_CI},
     packets::{ComChangeUser, ComChangeUserMoreData},
 };
@@ -26,30 +27,42 @@ impl Routine<()> for ChangeUser {
             mysql_async.connection.id = conn.id()
         );
 
-        let com_change_user = ComChangeUser::new()
-            .with_user(conn.opts().user().map(|x| x.as_bytes()))
-            .with_database(conn.opts().db_name().map(|x| x.as_bytes()))
-            .with_auth_plugin_data(
-                conn.inner
-                    .auth_plugin
-                    .gen_data(conn.opts().pass(), &conn.inner.nonce)
-                    .as_deref(),
-            )
-            .with_more_data(Some(
-                ComChangeUserMoreData::new(if conn.inner.version >= (5, 5, 3) {
-                    UTF8MB4_GENERAL_CI
-                } else {
-                    UTF8_GENERAL_CI
-                })
-                .with_auth_plugin(Some(conn.inner.auth_plugin.clone()))
-                .with_connect_attributes(conn.opts().connect_attributes().cloned()),
-            ))
-            .into_owned();
-
         let fut = async move {
+            // Initialize auth context and proc to generate auth data
+            let auth_context = crate::conn::AuthContext {
+                pass: conn.opts().pass().unwrap_or_default().to_owned(),
+                is_ipc_transport: conn.is_socket(),
+                is_tls_transport: conn.is_secure(),
+                scramble: conn.inner.nonce.clone(),
+                server_key_pem: conn.inner.server_key.clone(),
+            };
+
+            let mut auth_proc = conn.inner.auth_plugin.init()?;
+            let nonce = conn.inner.nonce.clone();
+            let response = auth_proc.run(auth_context.clone(), &nonce)?;
+
+            // Build COM_CHANGE_USER packet with generated auth data
+            let com_change_user = ComChangeUser::new()
+                .with_user(conn.opts().user().map(|x| x.as_bytes()))
+                .with_database(conn.opts().db_name().map(|x| x.as_bytes()))
+                .with_auth_plugin_data(response.data())
+                .with_more_data(Some(
+                    ComChangeUserMoreData::new(if conn.inner.version >= (5, 5, 3) {
+                        UTF8MB4_GENERAL_CI
+                    } else {
+                        UTF8_GENERAL_CI
+                    })
+                    .with_auth_plugin(Some(conn.inner.auth_plugin.clone()))
+                    .with_connect_attributes(conn.opts().connect_attributes().cloned()),
+                ))
+                .into_owned();
+
+            // Send COM_CHANGE_USER command
             conn.write_command(&com_change_user).await?;
-            conn.inner.auth_switched = false;
-            conn.continue_auth().await?;
+
+            // Handle authentication challenge-response loop
+            conn.continue_auth(false, auth_context, auth_proc, response)
+                .await?;
             Ok(())
         };
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,6 +11,7 @@ pub use url::ParseError;
 pub mod tls;
 
 use mysql_common::{
+    auth::plugins::{self, PluginInitError},
     named_params::MixedParamsError,
     packets::{BulkExecuteRequestBuilderError, BulkExecuteRequestError},
     params::{MissingNamedParameterError, ParamsError},
@@ -181,6 +182,12 @@ pub enum DriverError {
     #[error("Invalid parsec ext-salt packet received from server")]
     InvalidParsecSalt,
 
+    #[error("Server certificate cannot be validated")]
+    CertificateCannotBeValidated,
+
+    #[error("Auth plugin error: {0}")]
+    AuthPlugin(plugins::Error),
+
     #[error("Bulk execute error: {}", _0)]
     BulkExecute(BulkExecuteRequestError),
 }
@@ -197,6 +204,34 @@ impl From<BulkExecuteRequestBuilderError> for DriverError {
 impl From<BulkExecuteRequestError> for DriverError {
     fn from(value: BulkExecuteRequestError) -> Self {
         Self::BulkExecute(value)
+    }
+}
+
+impl From<plugins::Error> for Error {
+    fn from(err: plugins::Error) -> Self {
+        Self::Driver(DriverError::from(err))
+    }
+}
+
+impl From<plugins::Error> for DriverError {
+    fn from(err: plugins::Error) -> Self {
+        Self::AuthPlugin(err)
+    }
+}
+
+impl From<PluginInitError> for DriverError {
+    fn from(value: PluginInitError) -> Self {
+        match value {
+            PluginInitError::UnsupportedPlugin(name) => Self::UnknownAuthPlugin {
+                name: String::from_utf8_lossy(&name).into_owned(),
+            },
+        }
+    }
+}
+
+impl From<PluginInitError> for Error {
+    fn from(value: PluginInitError) -> Self {
+        Self::Driver(value.into())
     }
 }
 

--- a/src/io/tls/native_tls_io.rs
+++ b/src/io/tls/native_tls_io.rs
@@ -1,3 +1,5 @@
+use mysql_common::crypto::MariaDbZeroConfigCheck;
+use std::sync::{Arc, Mutex};
 use tokio_native_tls::native_tls::{self, Certificate};
 
 use crate::io::Endpoint;
@@ -17,7 +19,10 @@ impl SslOpts {
         Ok(output)
     }
 
-    pub(crate) async fn build_tls_connector(&self) -> Result<TlsConnector> {
+    pub(crate) async fn build_tls_connector(
+        &self,
+        _zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+    ) -> Result<TlsConnector> {
         let mut builder = native_tls::TlsConnector::builder();
         for root_cert in self.load_root_certs().await? {
             builder.add_root_certificate(root_cert);

--- a/src/io/tls/no_tls.rs
+++ b/src/io/tls/no_tls.rs
@@ -1,11 +1,16 @@
 use crate::io::Endpoint;
 use crate::{Result, SslOpts};
+use mysql_common::crypto::MariaDbZeroConfigCheck;
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub(crate) struct TlsConnector;
 
 impl SslOpts {
-    pub(crate) async fn build_tls_connector(&self) -> Result<TlsConnector> {
+    pub(crate) async fn build_tls_connector(
+        &self,
+        _zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+    ) -> Result<TlsConnector> {
         panic!(
             "Client had asked for TLS connection but TLS support is disabled. \
             Please enable one of the following features: [\"native-tls-tls\", \"rustls-tls\"]"

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -1,13 +1,16 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use mysql_common::crypto::MariaDbZeroConfigCheck;
 use rustls::{
     client::{
         danger::{ServerCertVerified, ServerCertVerifier},
         Resumption, WebPkiServerVerifier,
     },
     pki_types::{pem, CertificateDer, ServerName},
-    ClientConfig, RootCertStore,
+    CertificateError, ClientConfig, Error, RootCertStore,
 };
+use sha2::{Digest, Sha256};
+use x509_parser::{asn1_rs::FromDer, certificate::X509Certificate};
 
 pub(crate) use tokio_rustls::TlsConnector;
 
@@ -33,7 +36,10 @@ impl SslOpts {
         Ok(output)
     }
 
-    pub(crate) async fn build_tls_connector(&self) -> Result<TlsConnector> {
+    pub(crate) async fn build_tls_connector(
+        &self,
+        zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+    ) -> Result<TlsConnector> {
         let mut root_store = RootCertStore::empty();
         if !self.disable_built_in_roots() {
             root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|x| x.to_owned()));
@@ -64,6 +70,7 @@ impl SslOpts {
             self.accept_invalid_certs(),
             self.skip_domain_validation(),
             web_pki_verifier,
+            zero_config_check,
         );
         dangerous.set_certificate_verifier(Arc::new(dangerous_verifier));
         let client_config = Arc::new(config);
@@ -103,11 +110,25 @@ impl Endpoint {
     }
 }
 
-#[derive(Debug)]
 struct DangerousVerifier {
     accept_invalid_certs: bool,
     skip_domain_validation: bool,
     verifier: Arc<WebPkiServerVerifier>,
+    zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+}
+
+impl std::fmt::Debug for DangerousVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DangerousVerifier")
+            .field("accept_invalid_certs", &self.accept_invalid_certs)
+            .field("skip_domain_validation", &self.skip_domain_validation)
+            .field("verifier", &self.verifier)
+            .field(
+                "zero_config_check",
+                &self.zero_config_check.as_ref().map(|_| "<hidden>"),
+            )
+            .finish()
+    }
 }
 
 impl DangerousVerifier {
@@ -115,11 +136,13 @@ impl DangerousVerifier {
         accept_invalid_certs: bool,
         skip_domain_validation: bool,
         verifier: Arc<WebPkiServerVerifier>,
+        zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
     ) -> Self {
         Self {
             accept_invalid_certs,
             skip_domain_validation,
             verifier,
+            zero_config_check,
         }
     }
 }
@@ -177,6 +200,27 @@ impl ServerCertVerifier for DangerousVerifier {
                 Err(ref e)
                     if e.to_string().contains("NotValidForName") && self.skip_domain_validation =>
                 {
+                    Ok(ServerCertVerified::assertion())
+                }
+                Err(Error::InvalidCertificate(CertificateError::UnknownIssuer))
+                    if let Some(zero_config_check) = &self.zero_config_check =>
+                {
+                    // MariaDB zero-config TLS fallback applies only to self-signed ephemeral certs.
+                    let self_signed = X509Certificate::from_der(end_entity.as_ref())
+                        .map(|(_, cert)| cert.issuer() == cert.subject())
+                        .unwrap_or_default();
+
+                    if !self_signed {
+                        return Err(Error::InvalidCertificate(CertificateError::UnknownIssuer));
+                    }
+
+                    let mut hasher = Sha256::new();
+                    hasher.update(end_entity.as_ref());
+                    let fingerprint = hasher.finalize().to_vec();
+                    if let Ok(mut guard) = zero_config_check.lock() {
+                        *guard = Some(MariaDbZeroConfigCheck::new(Some(fingerprint)));
+                    }
+
                     Ok(ServerCertVerified::assertion())
                 }
                 Err(e) => Err(e),

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -727,6 +727,8 @@ pub(crate) struct MysqlOpts {
     /// When set, the client will advertise `CLIENT_CONNECT_ATTRS` and send the provided
     /// key-value attributes to the server.
     connect_attributes: Option<std::collections::HashMap<String, String>>,
+    /// Path to the server key file (defaults to `None`).
+    server_key_path: Option<PathBuf>,
 }
 
 /// Mysql connection options.
@@ -1177,6 +1179,11 @@ impl Opts {
         self.inner.mysql_opts.connect_attributes.as_ref()
     }
 
+    /// Returns server public key path (defaults to `None`).
+    pub fn get_server_key_path(&self) -> Option<&Path> {
+        self.inner.mysql_opts.server_key_path.as_deref()
+    }
+
     pub(crate) fn get_capabilities(&self) -> CapabilityFlags {
         let mut out = CapabilityFlags::CLIENT_PROTOCOL_41
             | CapabilityFlags::CLIENT_SECURE_CONNECTION
@@ -1241,10 +1248,15 @@ impl Default for MysqlOpts {
             client_found_rows: false,
             enable_cleartext_plugin: false,
             connect_attributes: None,
+            server_key_path: None,
         }
     }
 }
 
+/// This type is used to store SSL options and a cached TLS connector. The TLS connector is cached
+/// to avoid the overhead of creating a new connector for each connection, which can be expensive.
+/// In case of "zero config tls" (MariaDB 11.4+), the cached TLS connector is bypassed as it can't
+/// be shared in this case.
 #[derive(Clone)]
 pub(crate) struct SslOptsAndCachedConnector {
     ssl_opts: SslOpts,
@@ -1271,11 +1283,22 @@ impl SslOptsAndCachedConnector {
         &self.ssl_opts
     }
 
-    pub(crate) async fn build_tls_connector(&self) -> Result<crate::io::TlsConnector> {
-        self.tls_connector
-            .get_or_try_init(move || self.ssl_opts.build_tls_connector())
-            .await
-            .cloned()
+    pub(crate) async fn build_tls_connector(
+        &self,
+        zero_config_check: Option<
+            Arc<std::sync::Mutex<Option<mysql_common::crypto::MariaDbZeroConfigCheck>>>,
+        >,
+    ) -> Result<crate::io::TlsConnector> {
+        if zero_config_check.is_some() {
+            // Don't cache when zero_config_check is present
+            self.ssl_opts.build_tls_connector(zero_config_check).await
+        } else {
+            // Use cache when zero_config_check is None
+            self.tls_connector
+                .get_or_try_init(move || self.ssl_opts.build_tls_connector(None))
+                .await
+                .cloned()
+        }
     }
 }
 
@@ -1603,6 +1626,12 @@ impl OptsBuilder {
             .connect_attributes
             .get_or_insert_with(Default::default);
         map.insert(key.into(), value.into());
+        self
+    }
+
+    /// Sets the server public key path.
+    pub fn server_key_path(mut self, server_key_path: Option<PathBuf>) -> Self {
+        self.opts.server_key_path = server_key_path;
         self
     }
 }
@@ -2009,6 +2038,8 @@ fn mysql_opts_from_url(url: &Url) -> std::result::Result<MysqlOpts, UrlError> {
             }
         } else if key == "socket" {
             opts.socket = Some(value)
+        } else if key == "server_key_path" {
+            opts.server_key_path = Some(PathBuf::from(value));
         } else if key == "compression" {
             if value == "fast" {
                 opts.compression = Some(crate::Compression::fast());


### PR DESCRIPTION
It's based on auth plugins design change in mysql_common 0.38.0 - considers all changes added to the mysql-simple patch. In particular, it's only used if server's certificate is ephemeral and no CA is provided for connection - those were the latest additions.

I probably should have waited till you adopt this change in the async. Feel free to decline it :) I hope it still can be a good start.
=======
"Zero Config SSL" allows easy secure encrypted connection configuration with MariaDB server versions 11.4.1+. The only thing the application need for that is request encrypted connection and require certificate validation. The server can generate ephemeral certificate if needed. In case normal certificate validation failed the client still have chance to ensure that the certificate is valid and connection is secure. For this purpose the server send additional information - SHA256(password_hash || scramble || certificate fingerprint)). The client knows all three parts required to calculate this signature. If calculated and received hash match - the certificate is considered validated and the connection - secure.
This won't work with empty user passwords and insecure authentication plugins. i.e. it only work with native password, ed25519 and parsec plugins. In such case the error returned that the certificate could not be validated.

The feature is only supported with rustls backend only.